### PR TITLE
Define basic address space inheritance rules.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1324,7 +1324,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 89ebb6ab, updated Fri Oct 9 15:32:07 2020 -0700" name="generator">
   <link href="https://wicg.github.io/cors-rfc1918/" rel="canonical">
-  <meta content="a0df8fb2d0070000d76d17219b04f0f97a817147" name="document-revision">
+  <meta content="baebbdc20029b43b92f6b75d300e71d1d2b3cd2a" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -1891,7 +1891,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1>CORS and RFC1918</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-12-08">8 December 2020</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2020-12-10">10 December 2020</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1945,7 +1945,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
     <li>
      <a href="#framework"><span class="secno">2</span> <span class="content">Framework</span></a>
      <ol class="toc">
-      <li><a href="#address-space-heading"><span class="secno">2.1</span> <span class="content">Address Space</span></a>
+      <li><a href="#ip-address-space-heading"><span class="secno">2.1</span> <span class="content">IP Address Space</span></a>
       <li><a href="#private-network-request-heading"><span class="secno">2.2</span> <span class="content">Private Network Request</span></a>
       <li><a href="#headers"><span class="secno">2.3</span> <span class="content">Additional CORS Headers</span></a>
       <li><a href="#csp"><span class="secno">2.4</span> <span class="content">The <code>treat-as-public-address</code> Content Security Policy Directive</span></a>
@@ -2010,9 +2010,9 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
      <li data-md>
       <p>Users' routers, as outlined in <a data-link-type="biblio" href="#biblio-soho-pharming">[SOHO-PHARMING]</a>. Note that status quo
   CORS protections don’t protect against the kinds of attacks discussed here
-  as they rely only on <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-safelisted-method" id="ref-for-cors-safelisted-method">CORS-safelisted methods</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-safelisted-request-header" id="ref-for-cors-safelisted-request-header">CORS-safelisted request-headers</a>. No
-  preflight is triggered, and the attacker doesn’t actually care about
-  reading the response, as the request itself is the CSRF attack.</p>
+  as they rely only on <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-safelisted-method" id="ref-for-cors-safelisted-method">CORS-safelisted methods</a> and <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-safelisted-request-header" id="ref-for-cors-safelisted-request-header">CORS-safelisted request-headers</a>. No preflight is triggered, and the
+  attacker doesn’t actually care about reading the response, as the request
+  itself is the CSRF attack.</p>
      <li data-md>
       <p>Software running a web interface on a user’s loopback address. For better
   or worse, this is becoming a common deployment mechanism for all manner of
@@ -2034,8 +2034,7 @@ A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/
 &lt;/iframe>
 </pre>
      <p><code>router.local</code> will be resolved to the router’s address via the magic of
-    multicast DNS <a data-link-type="biblio" href="#biblio-rfc6762">[RFC6762]</a>, and the user agent will note it as <a data-link-type="dfn" href="#address-space-private" id="ref-for-address-space-private">private</a>. Since <code>csrf.attack</code> resolved to a <a data-link-type="dfn" href="#public-address" id="ref-for-public-address">public address</a>, the
-    request will trigger a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-preflight-request" id="ref-for-cors-preflight-request①">CORS-preflight request</a>:</p>
+    multicast DNS <a data-link-type="biblio" href="#biblio-rfc6762">[RFC6762]</a>, and the user agent will note it as <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private">private</a>. Since <code>csrf.attack</code> resolved to a <a data-link-type="dfn" href="#public-address" id="ref-for-public-address">public address</a>, the request will trigger a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-preflight-request" id="ref-for-cors-preflight-request①">CORS-preflight request</a>:</p>
 <pre>OPTIONS /set_dns?... HTTP/1.1
 Host: router.local
 <a data-link-type="http-header" href="https://fetch.spec.whatwg.org/#http-access-control-request-method" id="ref-for-http-access-control-request-method">Access-Control-Request-Method</a>: GET
@@ -2063,9 +2062,9 @@ Origin: https://csrf.attack
     for various reasons. They can explicitly opt-in to receiving requests from
     the internet by sending proper CORS headers in response to a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-preflight-request" id="ref-for-cors-preflight-request②">CORS-preflight request</a>. 
      <p>When a website on the public internet makes a request to the device, the
-    user agent determines that the requestor is <a data-link-type="dfn" href="#address-space-public" id="ref-for-address-space-public">public</a>, and the router
-    is <a data-link-type="dfn" href="#address-space-private" id="ref-for-address-space-private①">private</a>. This means that requests will trigger a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-preflight-request" id="ref-for-cors-preflight-request③">CORS-preflight
-    request</a>, just as above.</p>
+    user agent determines that the requestor is <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public">public</a>, and
+    the router is <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private①">private</a>. This means that requests will
+    trigger a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-preflight-request" id="ref-for-cors-preflight-request③">CORS-preflight request</a>, just as above.</p>
      <p>The device can explicitly grant access by sending the right headers in its
     response to the preflight request. For the above request, that might look
     like:</p>
@@ -2134,62 +2133,64 @@ Location: https://sekrits/super-sekrit-project-with-super-sekrit-partner
    </section>
    <section>
     <h2 class="heading settled" data-level="2" id="framework"><span class="secno">2. </span><span class="content">Framework</span><a class="self-link" href="#framework"></a></h2>
-    <h3 class="heading settled" data-level="2.1" id="address-space-heading"><span class="secno">2.1. </span><span class="content">Address Space</span><a class="self-link" href="#address-space-heading"></a></h3>
-    <p>Every IP address belongs to an IP <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="address-space">address space</dfn>, which can
-  be one of three different values:</p>
+    <h3 class="heading settled" data-level="2.1" id="ip-address-space-heading"><span class="secno">2.1. </span><span class="content">IP Address Space</span><a class="self-link" href="#ip-address-space-heading"></a></h3>
+    <p>Every IP address belongs to an <dfn class="dfn-paneled" data-dfn-type="dfn" data-export data-local-lt="address space" id="ip-address-space">IP address space</dfn>, which can be one
+  of three different values:</p>
     <ol>
      <li data-md>
-      <p><dfn class="dfn-paneled" data-dfn-for="address space" data-dfn-type="dfn" data-export id="address-space-local">local</dfn>: contains the local host only.
-  In other words, addresses whose target differs for every device.</p>
+      <p><dfn class="dfn-paneled" data-dfn-for="IP address space" data-dfn-type="dfn" data-export id="ip-address-space-local">local</dfn>: contains the local
+  host only. In other words, addresses whose target differs for every
+  device.</p>
      <li data-md>
-      <p><dfn class="dfn-paneled" data-dfn-for="address space" data-dfn-type="dfn" data-export id="address-space-private">private</dfn>: contains addresses that
-  have meaning only within the current network. In other words, addresses
-  whose target differs based on network position.</p>
+      <p><dfn class="dfn-paneled" data-dfn-for="IP address space" data-dfn-type="dfn" data-export id="ip-address-space-private">private</dfn>: contains
+  addresses that have meaning only within the current network. In other
+  words, addresses whose target differs based on network position.</p>
      <li data-md>
-      <p><dfn class="dfn-paneled" data-dfn-for="address space" data-dfn-type="dfn" data-export id="address-space-public">public</dfn>: contains all other
-  addresses. In other words, addresses whose target is the same for all
-  devices globally on the IP network.</p>
+      <p><dfn class="dfn-paneled" data-dfn-for="IP address space" data-dfn-type="dfn" data-export id="ip-address-space-public">public</dfn>: contains all
+  other addresses. In other words, addresses whose target is the same for
+  all devices globally on the IP network.</p>
     </ol>
-    <p>The contents of each <a data-link-type="dfn" href="#address-space" id="ref-for-address-space">address space</a> are determined in accordance with the
-  IANA Special-Purpose Address Registries (<a data-link-type="biblio" href="#biblio-ipv4-registry">[IPV4-REGISTRY]</a> and <a data-link-type="biblio" href="#biblio-ipv6-registry">[IPV6-REGISTRY]</a>). To determine the <a data-link-type="dfn" href="#address-space" id="ref-for-address-space①">address space</a> of a given IP address
+    <p>The contents of each <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space">IP address space</a> are determined in accordance with
+  the IANA Special-Purpose Address Registries (<a data-link-type="biblio" href="#biblio-ipv4-registry">[IPV4-REGISTRY]</a> and <a data-link-type="biblio" href="#biblio-ipv6-registry">[IPV6-REGISTRY]</a>). To determine the <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①">address space</a> of a given IP address
   (<var>address</var>), run the following steps:</p>
     <ol>
      <li data-md>
       <p>If <var>address</var> is an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-ipv4" id="ref-for-concept-ipv4">IPv4 address</a> in the "Loopback" address block
-  (<code>127.0.0.1/8</code> at time of writing), then return <a data-link-type="dfn" href="#address-space-local" id="ref-for-address-space-local">local</a>.</p>
+  (<code>127.0.0.1/8</code> at time of writing), then return <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local">local</a>.</p>
      <li data-md>
       <p>If <var>address</var> is an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-ipv6" id="ref-for-concept-ipv6">IPv6 address</a> in the "Loopback Address" address
-  block (<code>::1/128</code> at time of writing), then return <a data-link-type="dfn" href="#address-space-local" id="ref-for-address-space-local①">local</a>.</p>
+  block (<code>::1/128</code> at time of writing), then return <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local①">local</a>.</p>
      <li data-md>
       <p>If <var>address</var> is an IPv6 address in the "IPv4-mapped Address" address block
-  (<code>::ffff:0:0/96</code> at time of writing), return the <a data-link-type="dfn" href="#address-space" id="ref-for-address-space②">address space</a> of its
-  embedded IPv4 address.</p>
+  (<code>::ffff:0:0/96</code> at time of writing), return the <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space②">IP address space</a> of
+  its embedded IPv4 address.</p>
      <li data-md>
       <p>If <var>address</var> belongs to an address block for which the <code>Globally Reachable</code> bit is set to <code>False</code> in the relevant IANA registry,
-  then return <a data-link-type="dfn" href="#address-space-private" id="ref-for-address-space-private②">private</a>.</p>
+  then return <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private②">private</a>.</p>
      <li data-md>
-      <p>Otherwise return <a data-link-type="dfn" href="#address-space-public" id="ref-for-address-space-public①">public</a>.</p>
+      <p>Otherwise return <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public①">public</a>.</p>
     </ol>
-    <p class="note" role="note"><span>Note:</span> Link-local IP addresses such as <code>169.254.0.0/16</code> are considered <a data-link-type="dfn" href="#address-space-private" id="ref-for-address-space-private③">private</a>, since they can be shared among multiple devices on
-  a network link. A previous version of this specification considered them to be <a data-link-type="dfn" href="#address-space-local" id="ref-for-address-space-local②">local</a> instead.</p>
+    <p class="note" role="note"><span>Note:</span> Link-local IP addresses such as <code>169.254.0.0/16</code> are considered <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private③">private</a>, since such addresses can identify the same
+  target for all devices on a network link. A previous version of this
+  specification considered them to be <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local②">local</a> instead.</p>
     <p class="issue" id="issue-1456f875"><a class="self-link" href="#issue-1456f875"></a> Remove the special case for IPv4-mapped IPv6
   addresses once access to these addresses is blocked entirely. <a href="https://github.com/wicg/cors-rfc1918/issues/36">&lt;https://github.com/wicg/cors-rfc1918/issues/36></a></p>
     <p>For convenience, we additionally define the following terms:</p>
     <ol>
      <li data-md>
-      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="local-address">local address</dfn> is an address whose <a data-link-type="dfn" href="#address-space" id="ref-for-address-space③">address space</a> is <a data-link-type="dfn" href="#address-space-local" id="ref-for-address-space-local③">local</a>.</p>
+      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="local-address">local address</dfn> is an IP address whose <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space③">address space</a> is <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local③">local</a>.</p>
      <li data-md>
-      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="private-address">private address</dfn> is an address whose <a data-link-type="dfn" href="#address-space" id="ref-for-address-space④">address space</a> is <a data-link-type="dfn" href="#address-space-private" id="ref-for-address-space-private④">private</a>.</p>
+      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="private-address">private address</dfn> is an IP address whose <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space④">address space</a> is <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private④">private</a>.</p>
      <li data-md>
-      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="public-address">public address</dfn> is an address whose <a data-link-type="dfn" href="#address-space" id="ref-for-address-space⑤">address space</a> is <a data-link-type="dfn" href="#address-space-public" id="ref-for-address-space-public②">public</a>.</p>
+      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="public-address">public address</dfn> is an IP address whose <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space⑤">address space</a> is <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public②">public</a>.</p>
     </ol>
     <h3 class="heading settled" data-level="2.2" id="private-network-request-heading"><span class="secno">2.2. </span><span class="content">Private Network Request</span><a class="self-link" href="#private-network-request-heading"></a></h3>
     <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> (<var>request</var>) is a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="private-network-request">private network request</dfn> if any of the following are true:</p>
     <ol>
      <li data-md>
-      <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current url</a>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host">host</a></code> maps to a <a data-link-type="dfn" href="#private-address" id="ref-for-private-address①">private address</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a>’s <a data-link-type="dfn" href="#address-space" id="ref-for-address-space⑥">address space</a> is <a data-link-type="dfn" href="#address-space-public" id="ref-for-address-space-public③">public</a>.</p>
+      <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current url</a>'s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host">host</a></code> maps to a <a data-link-type="dfn" href="#private-address" id="ref-for-private-address①">private address</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a>'s <a data-link-type="dfn" href="#environment-settings-object-address-space" id="ref-for-environment-settings-object-address-space">address space</a> is <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public③">public</a>.</p>
      <li data-md>
-      <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current url</a>’s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host①">host</a></code> maps to a <a data-link-type="dfn" href="#local-address" id="ref-for-local-address">local address</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">client</a>’s <a data-link-type="dfn" href="#address-space" id="ref-for-address-space⑦">address space</a> is either <a data-link-type="dfn" href="#address-space-public" id="ref-for-address-space-public④">public</a> or <a data-link-type="dfn" href="#address-space-private" id="ref-for-address-space-private⑤">private</a>.</p>
+      <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current url</a>'s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host①">host</a></code> maps to a <a data-link-type="dfn" href="#local-address" id="ref-for-local-address">local address</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">client</a>'s <a data-link-type="dfn" href="#environment-settings-object-address-space" id="ref-for-environment-settings-object-address-space①">address space</a> is either <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public④">public</a> or <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private⑤">private</a>.</p>
     </ol>
     <h3 class="heading settled" data-level="2.3" id="headers"><span class="secno">2.3. </span><span class="content">Additional CORS Headers</span><a class="self-link" href="#headers"></a></h3>
     <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export id="http-headerdef-access-control-request-private-network"><code>Access-Control-Request-Private-Network</code></dfn> indicates that the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> is a <a data-link-type="dfn" href="#private-network-request" id="ref-for-private-network-request">private network request</a>.</p>
@@ -2207,11 +2208,12 @@ directive-value = ""
     <p>This directive has no reporting requirements; it will be ignored entirely when
   delivered in a <code>Content-Security-Policy-Report-Only</code> header, or within
   a <code><a data-link-type="element" href="https://html.spec.whatwg.org/multipage/semantics.html#meta" id="ref-for-meta">meta</a></code> element.</p>
-    <p>This directive’s <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-initialization" id="ref-for-directive-initialization">initialization</a> algorithm is as follows. Given a <code>Document</code> or <code>global object</code> (<var>context</var>), a <code>Response</code> (<var>response</var>), and
+    <p>This directive’s <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#directive-initialization" id="ref-for-directive-initialization">initialization</a> algorithm is as follows. Given an <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object">environment settings object</a> (<var>context</var>), a <code>Response</code> (<var>response</var>), and
   a <code>policy</code> (<var>policy</var>):</p>
     <ol>
      <li data-md>
-      <p>Set <var>context</var>’s <a data-link-type="dfn" href="#address-space" id="ref-for-address-space⑧">address space</a> to "<code>public</code>" if <var>policy</var>’s <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#policy-disposition" id="ref-for-policy-disposition">disposition</a> is "<code>enforce</code>".</p>
+      <p>Set <var>context</var>’s <a data-link-type="dfn" href="#environment-settings-object-address-space" id="ref-for-environment-settings-object-address-space②">address space</a> to <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public⑤">public</a> if <var>policy</var>’s <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#policy-disposition" id="ref-for-policy-disposition">disposition</a> is
+  "<code>enforce</code>".</p>
     </ol>
     <h3 class="heading settled" data-level="2.5" id="feature-detect"><span class="secno">2.5. </span><span class="content">Feature Detection</span><a class="self-link" href="#feature-detect"></a></h3>
     <p>To determine the address space in which a context finds itself, a simple enum
@@ -2226,7 +2228,7 @@ directive-value = ""
   <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#enumdef-addressspace" id="ref-for-enumdef-addressspace①"><c- n>AddressSpace</c-></a> <dfn class="idl-code" data-dfn-for="WorkerGlobalScope" data-dfn-type="attribute" data-export data-readonly data-type="AddressSpace" id="dom-workerglobalscope-addressspace"><code><c- g>addressSpace</c-></code><a class="self-link" href="#dom-workerglobalscope-addressspace"></a></dfn>;
 };
 </pre>
-    <p>Both attributes' getters return the value of the corresponding <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope②">WorkerGlobalScope</a></code>'s <a data-link-type="dfn" href="#address-space" id="ref-for-address-space⑨">address space</a> property.</p>
+    <p>Both attributes' getters return the value of the corresponding <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code>'s <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space">address space</a> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope②">WorkerGlobalScope</a></code>'s <a data-link-type="dfn" href="#workerglobalscope-address-space" id="ref-for-workerglobalscope-address-space">address space</a> property.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="3" id="integrations"><span class="secno">3. </span><span class="content">Integrations</span><a class="self-link" href="#integrations"></a></h2>
@@ -2240,8 +2242,8 @@ directive-value = ""
   implications:</p>
     <ol>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">Requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a>’s <a data-link-type="dfn" href="#address-space" id="ref-for-address-space①⓪">address space</a> is "<code>local</code>" are unchanged from status quo. They may continue to make
-  requests to <a data-link-type="dfn" href="#address-space-public" id="ref-for-address-space-public⑤">public</a>, <a data-link-type="dfn" href="#address-space-private" id="ref-for-address-space-private⑥">private</a>, and <a data-link-type="dfn" href="#address-space-local" id="ref-for-address-space-local④">local</a> addresses as
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">Requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a>'s <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space⑥">address space</a> is <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local④">local</a> are unchanged from status quo. They may
+  continue to make requests to IP addresses in any <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space⑦">address space</a> as
   they do today.</p>
       <p class="issue" id="issue-207ba0b9"><a class="self-link" href="#issue-207ba0b9"></a> Chris Palmer suggests that we might want
   to change the proposal such that private services must always opt-in to
@@ -2249,20 +2251,31 @@ directive-value = ""
   preflight for all cross-origin requests to private servers, whether they
   come from public addresses, or private addresses. <a href="https://github.com/wicg/cors-rfc1918/issues/1">&lt;https://github.com/wicg/cors-rfc1918/issues/1></a></p>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">Requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">client</a>’s <a data-link-type="dfn" href="#address-space" id="ref-for-address-space①①">address space</a> is "<code>private</code>" are allowed to fetch resources from <a data-link-type="dfn" href="#address-space-private" id="ref-for-address-space-private⑦">private</a> and <a data-link-type="dfn" href="#address-space-public" id="ref-for-address-space-public⑥">public</a> addresses as they do today, but may only request <a data-link-type="dfn" href="#address-space-local" id="ref-for-address-space-local⑤">local</a> resources if their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client④">client</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context" id="ref-for-secure-context">secure context</a> <em>and</em> a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-preflight-request" id="ref-for-cors-preflight-request⑤">CORS-preflight request</a> to the
-  target origin is successful.</p>
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">Requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">client</a>'s <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space⑧">address space</a> is <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private⑥">private</a> are allowed to fetch resources from <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private⑦">private</a> and <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public⑥">public</a> addresses as
+  they do today, but may only request <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local⑤">local</a> resources
+  if their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client④">client</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context" id="ref-for-secure-context">secure context</a> <strong>and</strong> a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-preflight-request" id="ref-for-cors-preflight-request⑤">CORS-preflight request</a> to the target origin is successful.</p>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">Requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑤">client</a>’s <a data-link-type="dfn" href="#address-space" id="ref-for-address-space①②">address space</a> is "<code>public</code>" are allowed to fetch resources from <a data-link-type="dfn" href="#address-space-public" id="ref-for-address-space-public⑦">public</a> addresses
-  as they do today, but may only request <a data-link-type="dfn" href="#address-space-private" id="ref-for-address-space-private⑧">private</a> and <a data-link-type="dfn" href="#address-space-local" id="ref-for-address-space-local⑥">local</a> resources if their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑥">client</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context" id="ref-for-secure-context①">secure context</a> <em>and</em> a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-preflight-request" id="ref-for-cors-preflight-request⑥">CORS-preflight request</a> to the target origin is
-  successful.</p>
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">Requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑤">client</a>'s <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space⑨">address space</a> is <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public⑦">public</a> are allowed to fetch resources from <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public⑧">public</a> addresses as they do today, but may only
+  request <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private⑧">private</a> and <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local⑥">local</a> resources if their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑥">client</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context" id="ref-for-secure-context①">secure context</a> <em>and</em> a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-preflight-request" id="ref-for-cors-preflight-request⑥">CORS-preflight request</a> to the target origin is successful.</p>
     </ol>
-    <p class="note" role="note"><span>Note:</span> UAs must not allow <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context" id="ref-for-secure-context②">non-secure</a> <a data-link-type="dfn" href="#address-space-public" id="ref-for-address-space-public⑧">public</a> contexts to request resources from <a data-link-type="dfn" href="#private-address" id="ref-for-private-address③">private
-  addresses</a>, even if the private server would opt-in to such a request via
-  a preflight. Making requests to <a data-link-type="dfn" href="#address-space-private" id="ref-for-address-space-private⑨">private</a> resources presents risks which
-  are mitigated by ensuring the integrity of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑦">client</a> which initiates the request. In particular, network attackers should not be
-  able to trivially exploit an endpoint’s consent to a non-secure origin.</p>
+    <p class="note" role="note"><span>Note:</span> UAs must not allow <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context" id="ref-for-secure-context②">non-secure</a> <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public⑨">public</a> contexts to request resources from <a data-link-type="dfn" href="#private-address" id="ref-for-private-address③">private addresses</a>, even if the private server would opt-in to such a
+  request via a preflight. Making requests to <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private⑨">private</a> resources presents risks which are mitigated by ensuring the integrity of the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑦">client</a> which initiates the request. In particular, network
+  attackers should not be able to trivially exploit an endpoint’s consent to a
+  non-secure origin.</p>
     <p>To those ends:</p>
     <ol>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-connection" id="ref-for-concept-connection">Connection</a> objects are given a new <dfn class="dfn-paneled" data-dfn-for="connection" data-dfn-type="dfn" data-export id="connection-address-space">address space</dfn>, whose value is the <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①⓪">IP address space</a> to which the connection’s remote endpoint belongs.
+  This applies to WebSocket connections too.</p>
+     <li data-md>
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">Response</a> objects are given a new <dfn class="dfn-paneled" data-dfn-for="response" data-dfn-type="dfn" data-export id="response-address-space">address space</dfn> property, whose value is
+  an <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①①">IP address space</a>, initially null.</p>
+     <li data-md>
+      <p>The <a data-link-type="abstract-op" href="https://fetch.spec.whatwg.org/#concept-http-network-fetch" id="ref-for-concept-http-network-fetch">HTTP-network fetch</a> algorithm is amended to add a new step in
+  between steps 7.1 and 7.2, after successfully obtaining a connection:</p>
+      <blockquote>
+       <p>7.2. Set <var>response</var>’s <a data-link-type="dfn" href="#response-address-space" id="ref-for-response-address-space">address space</a> to <var>connection</var>’s <a data-link-type="dfn" href="#connection-address-space" id="ref-for-connection-address-space">address space</a>.</p>
+      </blockquote>
      <li data-md>
       <p>The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch" id="ref-for-concept-http-fetch">HTTP fetch</a> algorithm should be adjusted to ensure that a
   preflight is triggered for all <a data-link-type="dfn" href="#private-network-request" id="ref-for-private-network-request①">private network requests</a>. This might
@@ -2372,23 +2385,65 @@ directive-value = ""
   beyond that and require a preflight. Not sure what the capabilities of the GET are, and how much
   control the caller has.</p>
     <h3 class="heading settled" data-level="3.3" id="integration-html"><span class="secno">3.3. </span><span class="content">Integration with HTML</span><a class="self-link" href="#integration-html"></a></h3>
-    <p>To support the checks in <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>, we store an <dfn class="dfn-paneled idl-code" data-dfn-for="Document" data-dfn-type="attribute" data-export id="dom-document-address-space"><code>address space</code></dfn> property on <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code> objects and a similar <dfn class="idl-code" data-dfn-for="WorkerGlobalScope" data-dfn-type="attribute" data-export id="dom-workerglobalscope-address-space"><code>address space</code><a class="self-link" href="#dom-workerglobalscope-address-space"></a></dfn> on <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope③">WorkerGlobalScope</a></code> objects, which is set as follows during <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code> and <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker">Worker</a></code> initialization:</p>
+    <p>To support the checks in <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>, user agents must remember the source <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①②">address space</a> of contexts in which network requests are made. To this
+  effect, the <a data-link-type="biblio" href="#biblio-html">[HTML]</a> specification is patched as follows:</p>
     <ol>
      <li data-md>
-      <p>Set <code class="idl"><a data-link-type="idl" href="#dom-document-address-space" id="ref-for-dom-document-address-space">address space</a></code> to "<code>local</code>" if the resource used to
-  instantiate the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker①">Worker</a></code> was delivered from a <a data-link-type="dfn" href="#local-address" id="ref-for-local-address①">local address</a>, or from a URL whose <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is "<code>file</code>" (see <a href="#file-url">§ 4.1 Where do file URLs fit?</a>).</p>
+      <p>An <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①③">address space</a> property is persisted on a number of objects:</p>
+      <ol>
+       <li data-md>
+        <p><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code> objects are given an <dfn class="dfn-paneled" data-dfn-for="Document" data-dfn-type="dfn" data-export id="document-address-space">address space</dfn> property, whose value
+  is an <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①④">IP address space</a>.</p>
+       <li data-md>
+        <p><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope③">WorkerGlobalScope</a></code> objects are given an <dfn class="dfn-paneled" data-dfn-for="WorkerGlobalScope" data-dfn-type="dfn" data-export id="workerglobalscope-address-space">address space</dfn> property,
+  whose value is an <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①⑤">IP address space</a>.</p>
+       <li data-md>
+        <p>[[Environment settings objects]] are given an <dfn class="dfn-paneled" data-dfn-for="environment settings object" data-dfn-type="dfn" data-export id="environment-settings-object-address-space">address space</dfn> accessor, which has the following implementations:</p>
+        <ol>
+         <li data-md>
+          <p>For <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window">Window</a></code> objects: return the <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space①">address space</a> of <var>window</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window">associated Document</a>.</p>
+         <li data-md>
+          <p>For <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope④">WorkerGlobalScope</a></code> objects: return <var>worker global scope</var>’s <a data-link-type="dfn" href="#workerglobalscope-address-space" id="ref-for-workerglobalscope-address-space①">address space</a>.</p>
+        </ol>
+      </ol>
      <li data-md>
-      <p>Set <code class="idl"><a data-link-type="idl" href="#dom-document-address-space" id="ref-for-dom-document-address-space①">address space</a></code> to "<code>private</code>" if the resource
-  used to instantiate the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker②">Worker</a></code> was delivered
-  from a <a data-link-type="dfn" href="#private-address" id="ref-for-private-address⑤">private address</a>.</p>
+      <p>The <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-browsing-context" id="ref-for-creating-a-new-browsing-context">create a new browsing context</a> algorithm is amended with an extra
+  step in between the existing steps 19 and 20. Thus the initial <code>about:blank</code> document inherits its creator’s <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space②">address space</a>:</p>
+      <blockquote>
+       <ol start="20">
+        <li data-md>
+         <p>If <var>creator</var> is non-null, then set <var>document</var>’s <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space③">address space</a> to to <var>creator</var>’s <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space④">address space</a>.</p>
+       </ol>
+      </blockquote>
      <li data-md>
-      <p>Set <code class="idl"><a data-link-type="idl" href="#dom-document-address-space" id="ref-for-dom-document-address-space②">address space</a></code> to "<code>public</code>" if the resource
-  used to instantiate the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#worker" id="ref-for-worker③">Worker</a></code> was delivered
-  from a <a data-link-type="dfn" href="#public-address" id="ref-for-public-address⑤">public address</a>.</p>
+      <p>The <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object" id="ref-for-initialise-the-document-object">initialize the Document object</a> algorithm is amended with an extra
+  step in between the existing steps 10 and 11, before the new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document④">Document</a></code>'s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list" id="ref-for-concept-document-csp-list">CSP list</a> is initialized:</p>
+      <blockquote>
+       <ol start="12">
+        <li data-md>
+         <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space⑤">address space</a> to <var>response</var>’s <a data-link-type="dfn" href="#response-address-space" id="ref-for-response-address-space①">address space</a>.</p>
+       </ol>
+      </blockquote>
+     <li data-md>
+      <p>The <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker" id="ref-for-run-a-worker">run a worker</a> algorithm is amended with two extra steps in between
+  the existing steps 14.4 and 14.5, after the new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope⑤">WorkerGlobalScope</a></code>'s
+  referrer policy is set:</p>
+      <blockquote>
+       <p>14.5. If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">url</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme">local scheme</a>, then set <var>worker global scope</var>’s <a data-link-type="dfn" href="#workerglobalscope-address-space" id="ref-for-workerglobalscope-address-space②">address space</a> to <var>owner</var>’s <a data-link-type="dfn" href="#workerglobalscope-address-space" id="ref-for-workerglobalscope-address-space③">address space</a>.
+14.5. Otherwise, set <var>worker global scope</var>’s <a data-link-type="dfn" href="#workerglobalscope-address-space" id="ref-for-workerglobalscope-address-space④">address space</a> to <var>response</var>’s <a data-link-type="dfn" href="#response-address-space" id="ref-for-response-address-space②">address space</a>.</p>
+      </blockquote>
     </ol>
-    <div class="example" id="example-58683bdd">
-     <a class="self-link" href="#example-58683bdd"></a> Assuming that <code>example.com</code> resolves to a <a data-link-type="dfn" href="#public-address" id="ref-for-public-address⑥">public address</a> (say, <code>123.123.123.123</code>), then the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑧">Document</a></code> created when navigating to <code>https://example.com/document.html</code> will have its <code class="idl"><a data-link-type="idl" href="#dom-document-address-space" id="ref-for-dom-document-address-space③">address space</a></code> property set to "<code>public</code>". 
-     <p>If, on the other hand, <code>example.com</code> resolved to a <a data-link-type="dfn" href="#local-address" id="ref-for-local-address②">local address</a> (say, <code>127.0.0.1</code>), then the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑨">Document</a></code> created when navigating to <code>https://example.com/document.html</code> will have its <code class="idl"><a data-link-type="idl" href="#dom-document-address-space" id="ref-for-dom-document-address-space④">address space</a></code> property set to "<code>local</code>".</p>
+    <p class="issue" id="issue-4a460a34"><a class="self-link" href="#issue-4a460a34"></a> Find a place to insert address space inheritance
+  from the navigation initiator for <code>data:</code> URLs. <a href="https://github.com/WICG/cors-rfc1918/issues/27">&lt;https://github.com/WICG/cors-rfc1918/issues/27></a></p>
+    <p class="issue" id="issue-a7434e9a"><a class="self-link" href="#issue-a7434e9a"></a> Capture the address space of the URL creator
+  when <code>createObjectUrl()</code> is called on a blob, and inherit that when loading
+  a document from the resulting URL. <a href="https://github.com/WICG/cors-rfc1918/issues/27">&lt;https://github.com/WICG/cors-rfc1918/issues/27></a></p>
+    <div class="example" id="example-2a60f30e">
+     <a class="self-link" href="#example-2a60f30e"></a> Assuming that <code>example.com</code> resolves to a <a data-link-type="dfn" href="#public-address" id="ref-for-public-address⑤">public address</a> (say, <code>123.123.123.123</code>), then the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code> created when navigating to <code>https://example.com/document.html</code> will have its <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space⑥">address space</a> property set to <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public①⓪">public</a>. 
+     <p>If this <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code> then embeds an <code>about:srcdoc</code> iframe, then the child
+    frame’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code> will have its <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space⑦">address space</a> property set
+    to <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public①①">public</a>.</p>
+     <p>If, on the other hand, <code>example.com</code> resolved to a <a data-link-type="dfn" href="#local-address" id="ref-for-local-address①">local address</a> (say, <code>127.0.0.1</code>), then the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑧">Document</a></code> created when navigating to <code>https://example.com/document.html</code> will have its <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space⑧">address space</a> property set to "<code>local</code>".</p>
     </div>
    </section>
    <section>
@@ -2398,9 +2453,8 @@ directive-value = ""
   outlined above. It would be nice to prevent folks from harming themselves by
   opening a malicious HTML file locally, on the one hand, but on the other, code
   running locally is somewhat outside of any sane threat model.</p>
-    <p>For the moment, let’s err on the side of treating <code>file</code> URLs as <a data-link-type="dfn" href="#address-space-local" id="ref-for-address-space-local⑦">local</a>,
-  as they seem to be just as much a part of the local system as anything else on
-  a loopback address.</p>
+    <p>For the moment, let’s err on the side of treating <code>file</code> URLs as <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local⑦">local</a>, as they seem to be just as much a part of the local
+  system as anything else on a loopback address.</p>
     <p class="issue" id="issue-5f05c8e3"><a class="self-link" href="#issue-5f05c8e3"></a> Reevaluate this after implementation experience.</p>
    </section>
    <section>
@@ -2415,11 +2469,12 @@ directive-value = ""
     <h3 class="heading settled" data-level="5.2" id="mixed-content"><span class="secno">5.2. </span><span class="content">Mixed Content</span><a class="self-link" href="#mixed-content"></a></h3>
     <p>Note that the CORS restrictions added by the proposal in this document do not
   obviate mixed content checks <a data-link-type="biblio" href="#biblio-mixed-content">[MIXED-CONTENT]</a>. Developers who wish to
-  fetch <a data-link-type="dfn" href="#address-space-private" id="ref-for-address-space-private①⓪">private</a> resources from <a data-link-type="dfn" href="#address-space-public" id="ref-for-address-space-public⑨">public</a> pages MUST ensure that the
-  connection is secure. This might involve a solution along the lines of <a data-link-type="biblio" href="#biblio-plex">[PLEX]</a>, or we might end up inventing a new way of ensuring a secure
-  connection to devices (perhaps the pairing ceremony hinted at above, or one of
-  the ideas floated in <a data-link-type="biblio" href="#biblio-secure-local-communication">[SECURE-LOCAL-COMMUNICATION]</a>?). In either case,
-  consenting to access by sending proper CORS is necessary, but not sufficient.</p>
+  fetch <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private①⓪">private</a> resources from <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public①②">public</a> pages MUST ensure that the connection is secure. This might involve a solution
+  along the lines of <a data-link-type="biblio" href="#biblio-plex">[PLEX]</a>, or we might end up inventing a new way of
+  ensuring a secure connection to devices (perhaps the pairing ceremony hinted
+  at above, or one of the ideas floated in <a data-link-type="biblio" href="#biblio-secure-local-communication">[SECURE-LOCAL-COMMUNICATION]</a>?). In
+  either case, consenting to access by sending proper CORS is necessary, but not
+  sufficient.</p>
     <p class="note" role="note"><span>Note:</span> Doing something like the proposal here would make me more comfortable
   with relaxing the mixed content restrictions that prohibit unencrypted
   connections to loopback addresses. Right now, those aren’t really subject to
@@ -2599,9 +2654,12 @@ directive-value = ""
    <li>
     address space
     <ul>
-     <li><a href="#dom-document-address-space">attribute for Document</a><span>, in §3.3</span>
-     <li><a href="#dom-workerglobalscope-address-space">attribute for WorkerGlobalScope</a><span>, in §3.3</span>
-     <li><a href="#address-space">definition of</a><span>, in §2.1</span>
+     <li><a href="#ip-address-space">definition of</a><span>, in §2.1</span>
+     <li><a href="#document-address-space">dfn for Document</a><span>, in §3.3</span>
+     <li><a href="#workerglobalscope-address-space">dfn for WorkerGlobalScope</a><span>, in §3.3</span>
+     <li><a href="#connection-address-space">dfn for connection</a><span>, in §3.1</span>
+     <li><a href="#environment-settings-object-address-space">dfn for environment settings object</a><span>, in §3.3</span>
+     <li><a href="#response-address-space">dfn for response</a><span>, in §3.1</span>
     </ul>
    <li><a href="#enumdef-addressspace">AddressSpace</a><span>, in §2.5</span>
    <li>
@@ -2610,15 +2668,16 @@ directive-value = ""
      <li><a href="#dom-document-addressspace">attribute for Document</a><span>, in §2.5</span>
      <li><a href="#dom-workerglobalscope-addressspace">attribute for WorkerGlobalScope</a><span>, in §2.5</span>
     </ul>
+   <li><a href="#ip-address-space">IP address space</a><span>, in §2.1</span>
    <li><a href="#dom-addressspace-local">"local"</a><span>, in §2.5</span>
-   <li><a href="#address-space-local">local</a><span>, in §2.1</span>
+   <li><a href="#ip-address-space-local">local</a><span>, in §2.1</span>
    <li><a href="#local-address">local address</a><span>, in §2.1</span>
    <li><a href="#dom-addressspace-private">"private"</a><span>, in §2.5</span>
-   <li><a href="#address-space-private">private</a><span>, in §2.1</span>
+   <li><a href="#ip-address-space-private">private</a><span>, in §2.1</span>
    <li><a href="#private-address">private address</a><span>, in §2.1</span>
    <li><a href="#private-network-request">private network request</a><span>, in §2.2</span>
    <li><a href="#dom-addressspace-public">"public"</a><span>, in §2.5</span>
-   <li><a href="#address-space-public">public</a><span>, in §2.1</span>
+   <li><a href="#ip-address-space-public">public</a><span>, in §2.1</span>
    <li><a href="#public-address">public address</a><span>, in §2.1</span>
    <li><a href="#cache-request-network-type">request network type</a><span>, in §3.1</span>
    <li><a href="#treat-as-public-address">treat-as-public-address</a><span>, in §2.4</span>
@@ -2674,6 +2733,12 @@ directive-value = ""
    <ul>
     <li><a href="#ref-for-concept-request-client">2.2. Private Network Request</a> <a href="#ref-for-concept-request-client①">(2)</a>
     <li><a href="#ref-for-concept-request-client②">3.1. Integration with Fetch</a> <a href="#ref-for-concept-request-client③">(2)</a> <a href="#ref-for-concept-request-client④">(3)</a> <a href="#ref-for-concept-request-client⑤">(4)</a> <a href="#ref-for-concept-request-client⑥">(5)</a> <a href="#ref-for-concept-request-client⑦">(6)</a> <a href="#ref-for-concept-request-client⑧">(7)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-connection">
+   <a href="https://fetch.spec.whatwg.org/#concept-connection">https://fetch.spec.whatwg.org/#concept-connection</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-connection">3.1. Integration with Fetch</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-cache">
@@ -2742,6 +2807,12 @@ directive-value = ""
     <li><a href="#ref-for-concept-http-fetch">3.1. Integration with Fetch</a> <a href="#ref-for-concept-http-fetch①">(2)</a> <a href="#ref-for-concept-http-fetch②">(3)</a> <a href="#ref-for-concept-http-fetch③">(4)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-local-scheme">
+   <a href="https://fetch.spec.whatwg.org/#local-scheme">https://fetch.spec.whatwg.org/#local-scheme</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-local-scheme">3.3. Integration with HTML</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-concept-network-error">
    <a href="https://fetch.spec.whatwg.org/#concept-network-error">https://fetch.spec.whatwg.org/#concept-network-error</a><b>Referenced in:</b>
    <ul>
@@ -2763,36 +2834,90 @@ directive-value = ""
     <li><a href="#ref-for-concept-request②">3.1. Integration with Fetch</a> <a href="#ref-for-concept-request③">(2)</a> <a href="#ref-for-concept-request④">(3)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-response">
+   <a href="https://fetch.spec.whatwg.org/#concept-response">https://fetch.spec.whatwg.org/#concept-response</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-response">3.1. Integration with Fetch</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-concept-header-list-set">
    <a href="https://fetch.spec.whatwg.org/#concept-header-list-set">https://fetch.spec.whatwg.org/#concept-header-list-set</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-concept-header-list-set">3.1. Integration with Fetch</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-response-url">
+   <a href="https://fetch.spec.whatwg.org/#concept-response-url">https://fetch.spec.whatwg.org/#concept-response-url</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-response-url">3.3. Integration with HTML</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="term-for-document">
    <a href="https://html.spec.whatwg.org/#document">https://html.spec.whatwg.org/#document</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-document">2.5. Feature Detection</a> <a href="#ref-for-document①">(2)</a> <a href="#ref-for-document②">(3)</a>
-    <li><a href="#ref-for-document③">3.3. Integration with HTML</a> <a href="#ref-for-document④">(2)</a> <a href="#ref-for-document⑤">(3)</a> <a href="#ref-for-document⑥">(4)</a> <a href="#ref-for-document⑦">(5)</a> <a href="#ref-for-document⑧">(6)</a> <a href="#ref-for-document⑨">(7)</a>
+    <li><a href="#ref-for-document③">3.3. Integration with HTML</a> <a href="#ref-for-document④">(2)</a> <a href="#ref-for-document⑤">(3)</a> <a href="#ref-for-document⑥">(4)</a> <a href="#ref-for-document⑦">(5)</a> <a href="#ref-for-document⑧">(6)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="term-for-worker">
-   <a href="https://html.spec.whatwg.org/multipage/workers.html#worker">https://html.spec.whatwg.org/multipage/workers.html#worker</a><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="term-for-concept-http-network-fetch">
+   <a href="https://fetch.spec.whatwg.org/#concept-http-network-fetch">https://fetch.spec.whatwg.org/#concept-http-network-fetch</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-worker">3.3. Integration with HTML</a> <a href="#ref-for-worker①">(2)</a> <a href="#ref-for-worker②">(3)</a> <a href="#ref-for-worker③">(4)</a>
+    <li><a href="#ref-for-concept-http-network-fetch">3.1. Integration with Fetch</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-window">
+   <a href="https://html.spec.whatwg.org/multipage/window-object.html#window">https://html.spec.whatwg.org/multipage/window-object.html#window</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-window">3.3. Integration with HTML</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-workerglobalscope">
    <a href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope">https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-workerglobalscope">2.5. Feature Detection</a> <a href="#ref-for-workerglobalscope①">(2)</a> <a href="#ref-for-workerglobalscope②">(3)</a>
-    <li><a href="#ref-for-workerglobalscope③">3.3. Integration with HTML</a>
+    <li><a href="#ref-for-workerglobalscope③">3.3. Integration with HTML</a> <a href="#ref-for-workerglobalscope④">(2)</a> <a href="#ref-for-workerglobalscope⑤">(3)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-document-window">
+   <a href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window">https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-document-window">3.3. Integration with HTML</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-creating-a-new-browsing-context">
+   <a href="https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-browsing-context">https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-browsing-context</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-creating-a-new-browsing-context">3.3. Integration with HTML</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-concept-document-csp-list">
+   <a href="https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list">https://html.spec.whatwg.org/multipage/dom.html#concept-document-csp-list</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-concept-document-csp-list">3.3. Integration with HTML</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-environment-settings-object">
+   <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-environment-settings-object">2.4. The treat-as-public-address Content Security Policy Directive</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-initialise-the-document-object">
+   <a href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object">https://html.spec.whatwg.org/multipage/browsing-the-web.html#initialise-the-document-object</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-initialise-the-document-object">3.3. Integration with HTML</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-meta">
    <a href="https://html.spec.whatwg.org/multipage/semantics.html#meta">https://html.spec.whatwg.org/multipage/semantics.html#meta</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-meta">2.4. The treat-as-public-address Content Security Policy Directive</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="term-for-run-a-worker">
+   <a href="https://html.spec.whatwg.org/multipage/workers.html#run-a-worker">https://html.spec.whatwg.org/multipage/workers.html#run-a-worker</a><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-run-a-worker">3.3. Integration with HTML</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-secure-context">
@@ -2810,13 +2935,13 @@ directive-value = ""
   <aside class="dfn-panel" data-for="term-for-concept-ipv4">
    <a href="https://url.spec.whatwg.org/#concept-ipv4">https://url.spec.whatwg.org/#concept-ipv4</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-ipv4">2.1. Address Space</a>
+    <li><a href="#ref-for-concept-ipv4">2.1. IP Address Space</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-ipv6">
    <a href="https://url.spec.whatwg.org/#concept-ipv6">https://url.spec.whatwg.org/#concept-ipv6</a><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-concept-ipv6">2.1. Address Space</a>
+    <li><a href="#ref-for-concept-ipv6">2.1. IP Address Space</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-concept-url-scheme">
@@ -2842,6 +2967,7 @@ directive-value = ""
      <li><span class="dfn-paneled" id="term-for-http-access-control-request-method">access-control-request-method</span>
      <li><span class="dfn-paneled" id="term-for-concept-header-list-append">append</span>
      <li><span class="dfn-paneled" id="term-for-concept-request-client">client</span>
+     <li><span class="dfn-paneled" id="term-for-concept-connection">connection</span>
      <li><span class="dfn-paneled" id="term-for-concept-cache">cors-preflight cache</span>
      <li><span class="dfn-paneled" id="term-for-cors-preflight-fetch-0">cors-preflight fetch</span>
      <li><span class="dfn-paneled" id="term-for-cors-preflight-request">cors-preflight request</span>
@@ -2852,18 +2978,28 @@ directive-value = ""
      <li><span class="dfn-paneled" id="term-for-extract-header-list-values">extracting header list values</span>
      <li><span class="dfn-paneled" id="term-for-concept-response-header-list">header list <small>(for response)</small></span>
      <li><span class="dfn-paneled" id="term-for-concept-http-fetch">http fetch</span>
+     <li><span class="dfn-paneled" id="term-for-local-scheme">local scheme</span>
      <li><span class="dfn-paneled" id="term-for-concept-network-error">network error</span>
      <li><span class="dfn-paneled" id="term-for-concept-connection-obtain">obtain a connection</span>
      <li><span class="dfn-paneled" id="term-for-concept-request">request</span>
+     <li><span class="dfn-paneled" id="term-for-concept-response">response</span>
      <li><span class="dfn-paneled" id="term-for-concept-header-list-set">set</span>
+     <li><span class="dfn-paneled" id="term-for-concept-response-url">url</span>
     </ul>
    <li>
     <a data-link-type="biblio">[HTML]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-document">Document</span>
-     <li><span class="dfn-paneled" id="term-for-worker">Worker</span>
+     <li><span class="dfn-paneled" id="term-for-concept-http-network-fetch">HTTP-network fetch</span>
+     <li><span class="dfn-paneled" id="term-for-window">Window</span>
      <li><span class="dfn-paneled" id="term-for-workerglobalscope">WorkerGlobalScope</span>
+     <li><span class="dfn-paneled" id="term-for-concept-document-window">associated document</span>
+     <li><span class="dfn-paneled" id="term-for-creating-a-new-browsing-context">create a new browsing context</span>
+     <li><span class="dfn-paneled" id="term-for-concept-document-csp-list">csp list</span>
+     <li><span class="dfn-paneled" id="term-for-environment-settings-object">environment settings object</span>
+     <li><span class="dfn-paneled" id="term-for-initialise-the-document-object">initialize the Document object</span>
      <li><span class="dfn-paneled" id="term-for-meta">meta</span>
+     <li><span class="dfn-paneled" id="term-for-run-a-worker">run a worker</span>
      <li><span class="dfn-paneled" id="term-for-secure-context">secure context</span>
     </ul>
    <li>
@@ -2948,52 +3084,57 @@ directive-value = ""
    <div class="issue"> Look into this. Adding headers to the handshake seems reasonable, but we might need to go
   beyond that and require a preflight. Not sure what the capabilities of the GET are, and how much
   control the caller has.<a href="#issue-28debeec"> ↵ </a></div>
+   <div class="issue"> Find a place to insert address space inheritance
+  from the navigation initiator for <code>data:</code> URLs. <a href="https://github.com/WICG/cors-rfc1918/issues/27">&lt;https://github.com/WICG/cors-rfc1918/issues/27></a><a href="#issue-4a460a34"> ↵ </a></div>
+   <div class="issue"> Capture the address space of the URL creator
+  when <code>createObjectUrl()</code> is called on a blob, and inherit that when loading
+  a document from the resulting URL. <a href="https://github.com/WICG/cors-rfc1918/issues/27">&lt;https://github.com/WICG/cors-rfc1918/issues/27></a><a href="#issue-a7434e9a"> ↵ </a></div>
    <div class="issue"> Reevaluate this after implementation experience.<a href="#issue-5f05c8e3"> ↵ </a></div>
   </div>
-  <aside class="dfn-panel" data-for="address-space">
-   <b><a href="#address-space">#address-space</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="ip-address-space">
+   <b><a href="#ip-address-space">#ip-address-space</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-address-space">2.1. Address Space</a> <a href="#ref-for-address-space①">(2)</a> <a href="#ref-for-address-space②">(3)</a> <a href="#ref-for-address-space③">(4)</a> <a href="#ref-for-address-space④">(5)</a> <a href="#ref-for-address-space⑤">(6)</a>
-    <li><a href="#ref-for-address-space⑥">2.2. Private Network Request</a> <a href="#ref-for-address-space⑦">(2)</a>
-    <li><a href="#ref-for-address-space⑧">2.4. The treat-as-public-address Content Security Policy Directive</a>
-    <li><a href="#ref-for-address-space⑨">2.5. Feature Detection</a>
-    <li><a href="#ref-for-address-space①⓪">3.1. Integration with Fetch</a> <a href="#ref-for-address-space①①">(2)</a> <a href="#ref-for-address-space①②">(3)</a>
+    <li><a href="#ref-for-ip-address-space">2.1. IP Address Space</a> <a href="#ref-for-ip-address-space①">(2)</a> <a href="#ref-for-ip-address-space②">(3)</a> <a href="#ref-for-ip-address-space③">(4)</a> <a href="#ref-for-ip-address-space④">(5)</a> <a href="#ref-for-ip-address-space⑤">(6)</a>
+    <li><a href="#ref-for-ip-address-space⑥">3.1. Integration with Fetch</a> <a href="#ref-for-ip-address-space⑦">(2)</a> <a href="#ref-for-ip-address-space⑧">(3)</a> <a href="#ref-for-ip-address-space⑨">(4)</a> <a href="#ref-for-ip-address-space①⓪">(5)</a> <a href="#ref-for-ip-address-space①①">(6)</a>
+    <li><a href="#ref-for-ip-address-space①②">3.3. Integration with HTML</a> <a href="#ref-for-ip-address-space①③">(2)</a> <a href="#ref-for-ip-address-space①④">(3)</a> <a href="#ref-for-ip-address-space①⑤">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="address-space-local">
-   <b><a href="#address-space-local">#address-space-local</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="ip-address-space-local">
+   <b><a href="#ip-address-space-local">#ip-address-space-local</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-address-space-local">2.1. Address Space</a> <a href="#ref-for-address-space-local①">(2)</a> <a href="#ref-for-address-space-local②">(3)</a> <a href="#ref-for-address-space-local③">(4)</a>
-    <li><a href="#ref-for-address-space-local④">3.1. Integration with Fetch</a> <a href="#ref-for-address-space-local⑤">(2)</a> <a href="#ref-for-address-space-local⑥">(3)</a>
-    <li><a href="#ref-for-address-space-local⑦">4.1. Where do file URLs fit?</a>
+    <li><a href="#ref-for-ip-address-space-local">2.1. IP Address Space</a> <a href="#ref-for-ip-address-space-local①">(2)</a> <a href="#ref-for-ip-address-space-local②">(3)</a> <a href="#ref-for-ip-address-space-local③">(4)</a>
+    <li><a href="#ref-for-ip-address-space-local④">3.1. Integration with Fetch</a> <a href="#ref-for-ip-address-space-local⑤">(2)</a> <a href="#ref-for-ip-address-space-local⑥">(3)</a>
+    <li><a href="#ref-for-ip-address-space-local⑦">4.1. Where do file URLs fit?</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="address-space-private">
-   <b><a href="#address-space-private">#address-space-private</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="ip-address-space-private">
+   <b><a href="#ip-address-space-private">#ip-address-space-private</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-address-space-private">1.2.1. Secure by Default</a>
-    <li><a href="#ref-for-address-space-private①">1.2.2. Opting-In</a>
-    <li><a href="#ref-for-address-space-private②">2.1. Address Space</a> <a href="#ref-for-address-space-private③">(2)</a> <a href="#ref-for-address-space-private④">(3)</a>
-    <li><a href="#ref-for-address-space-private⑤">2.2. Private Network Request</a>
-    <li><a href="#ref-for-address-space-private⑥">3.1. Integration with Fetch</a> <a href="#ref-for-address-space-private⑦">(2)</a> <a href="#ref-for-address-space-private⑧">(3)</a> <a href="#ref-for-address-space-private⑨">(4)</a>
-    <li><a href="#ref-for-address-space-private①⓪">5.2. Mixed Content</a>
+    <li><a href="#ref-for-ip-address-space-private">1.2.1. Secure by Default</a>
+    <li><a href="#ref-for-ip-address-space-private①">1.2.2. Opting-In</a>
+    <li><a href="#ref-for-ip-address-space-private②">2.1. IP Address Space</a> <a href="#ref-for-ip-address-space-private③">(2)</a> <a href="#ref-for-ip-address-space-private④">(3)</a>
+    <li><a href="#ref-for-ip-address-space-private⑤">2.2. Private Network Request</a>
+    <li><a href="#ref-for-ip-address-space-private⑥">3.1. Integration with Fetch</a> <a href="#ref-for-ip-address-space-private⑦">(2)</a> <a href="#ref-for-ip-address-space-private⑧">(3)</a> <a href="#ref-for-ip-address-space-private⑨">(4)</a>
+    <li><a href="#ref-for-ip-address-space-private①⓪">5.2. Mixed Content</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="address-space-public">
-   <b><a href="#address-space-public">#address-space-public</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="ip-address-space-public">
+   <b><a href="#ip-address-space-public">#ip-address-space-public</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-address-space-public">1.2.2. Opting-In</a>
-    <li><a href="#ref-for-address-space-public①">2.1. Address Space</a> <a href="#ref-for-address-space-public②">(2)</a>
-    <li><a href="#ref-for-address-space-public③">2.2. Private Network Request</a> <a href="#ref-for-address-space-public④">(2)</a>
-    <li><a href="#ref-for-address-space-public⑤">3.1. Integration with Fetch</a> <a href="#ref-for-address-space-public⑥">(2)</a> <a href="#ref-for-address-space-public⑦">(3)</a> <a href="#ref-for-address-space-public⑧">(4)</a>
-    <li><a href="#ref-for-address-space-public⑨">5.2. Mixed Content</a>
+    <li><a href="#ref-for-ip-address-space-public">1.2.2. Opting-In</a>
+    <li><a href="#ref-for-ip-address-space-public①">2.1. IP Address Space</a> <a href="#ref-for-ip-address-space-public②">(2)</a>
+    <li><a href="#ref-for-ip-address-space-public③">2.2. Private Network Request</a> <a href="#ref-for-ip-address-space-public④">(2)</a>
+    <li><a href="#ref-for-ip-address-space-public⑤">2.4. The treat-as-public-address Content Security Policy Directive</a>
+    <li><a href="#ref-for-ip-address-space-public⑥">3.1. Integration with Fetch</a> <a href="#ref-for-ip-address-space-public⑦">(2)</a> <a href="#ref-for-ip-address-space-public⑧">(3)</a> <a href="#ref-for-ip-address-space-public⑨">(4)</a>
+    <li><a href="#ref-for-ip-address-space-public①⓪">3.3. Integration with HTML</a> <a href="#ref-for-ip-address-space-public①①">(2)</a>
+    <li><a href="#ref-for-ip-address-space-public①②">5.2. Mixed Content</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="local-address">
    <b><a href="#local-address">#local-address</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-local-address">2.2. Private Network Request</a>
-    <li><a href="#ref-for-local-address①">3.3. Integration with HTML</a> <a href="#ref-for-local-address②">(2)</a>
+    <li><a href="#ref-for-local-address①">3.3. Integration with HTML</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="private-address">
@@ -3003,7 +3144,6 @@ directive-value = ""
     <li><a href="#ref-for-private-address①">2.2. Private Network Request</a>
     <li><a href="#ref-for-private-address②">2.4. The treat-as-public-address Content Security Policy Directive</a>
     <li><a href="#ref-for-private-address③">3.1. Integration with Fetch</a> <a href="#ref-for-private-address④">(2)</a>
-    <li><a href="#ref-for-private-address⑤">3.3. Integration with HTML</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="public-address">
@@ -3013,7 +3153,7 @@ directive-value = ""
     <li><a href="#ref-for-public-address①">1.2.3. Navigation</a> <a href="#ref-for-public-address②">(2)</a>
     <li><a href="#ref-for-public-address③">2.4. The treat-as-public-address Content Security Policy Directive</a>
     <li><a href="#ref-for-public-address④">3.1. Integration with Fetch</a>
-    <li><a href="#ref-for-public-address⑤">3.3. Integration with HTML</a> <a href="#ref-for-public-address⑥">(2)</a>
+    <li><a href="#ref-for-public-address⑤">3.3. Integration with HTML</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="private-network-request">
@@ -3055,16 +3195,44 @@ directive-value = ""
     <li><a href="#ref-for-enumdef-addressspace">2.5. Feature Detection</a> <a href="#ref-for-enumdef-addressspace①">(2)</a>
    </ul>
   </aside>
+  <aside class="dfn-panel" data-for="connection-address-space">
+   <b><a href="#connection-address-space">#connection-address-space</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-connection-address-space">3.1. Integration with Fetch</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="response-address-space">
+   <b><a href="#response-address-space">#response-address-space</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-response-address-space">3.1. Integration with Fetch</a>
+    <li><a href="#ref-for-response-address-space①">3.3. Integration with HTML</a> <a href="#ref-for-response-address-space②">(2)</a>
+   </ul>
+  </aside>
   <aside class="dfn-panel" data-for="cache-request-network-type">
    <b><a href="#cache-request-network-type">#cache-request-network-type</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-cache-request-network-type">3.1. Integration with Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="dom-document-address-space">
-   <b><a href="#dom-document-address-space">#dom-document-address-space</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="document-address-space">
+   <b><a href="#document-address-space">#document-address-space</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-dom-document-address-space">3.3. Integration with HTML</a> <a href="#ref-for-dom-document-address-space①">(2)</a> <a href="#ref-for-dom-document-address-space②">(3)</a> <a href="#ref-for-dom-document-address-space③">(4)</a> <a href="#ref-for-dom-document-address-space④">(5)</a>
+    <li><a href="#ref-for-document-address-space">2.5. Feature Detection</a>
+    <li><a href="#ref-for-document-address-space①">3.3. Integration with HTML</a> <a href="#ref-for-document-address-space②">(2)</a> <a href="#ref-for-document-address-space③">(3)</a> <a href="#ref-for-document-address-space④">(4)</a> <a href="#ref-for-document-address-space⑤">(5)</a> <a href="#ref-for-document-address-space⑥">(6)</a> <a href="#ref-for-document-address-space⑦">(7)</a> <a href="#ref-for-document-address-space⑧">(8)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="workerglobalscope-address-space">
+   <b><a href="#workerglobalscope-address-space">#workerglobalscope-address-space</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-workerglobalscope-address-space">2.5. Feature Detection</a>
+    <li><a href="#ref-for-workerglobalscope-address-space①">3.3. Integration with HTML</a> <a href="#ref-for-workerglobalscope-address-space②">(2)</a> <a href="#ref-for-workerglobalscope-address-space③">(3)</a> <a href="#ref-for-workerglobalscope-address-space④">(4)</a>
+   </ul>
+  </aside>
+  <aside class="dfn-panel" data-for="environment-settings-object-address-space">
+   <b><a href="#environment-settings-object-address-space">#environment-settings-object-address-space</a></b><b>Referenced in:</b>
+   <ul>
+    <li><a href="#ref-for-environment-settings-object-address-space">2.2. Private Network Request</a> <a href="#ref-for-environment-settings-object-address-space①">(2)</a>
+    <li><a href="#ref-for-environment-settings-object-address-space②">2.4. The treat-as-public-address Content Security Policy Directive</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/index.html
+++ b/index.html
@@ -1324,7 +1324,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 89ebb6ab, updated Fri Oct 9 15:32:07 2020 -0700" name="generator">
   <link href="https://wicg.github.io/cors-rfc1918/" rel="canonical">
-  <meta content="baebbdc20029b43b92f6b75d300e71d1d2b3cd2a" name="document-revision">
+  <meta content="b930d98ad75be7c8608007bca60e0125893af10b" name="document-revision">
 <style>
   ul.toc ul ul ul {
     margin: 0 0 0 2em;
@@ -2151,8 +2151,8 @@ Location: https://sekrits/super-sekrit-project-with-super-sekrit-partner
   all devices globally on the IP network.</p>
     </ol>
     <p>The contents of each <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space">IP address space</a> are determined in accordance with
-  the IANA Special-Purpose Address Registries (<a data-link-type="biblio" href="#biblio-ipv4-registry">[IPV4-REGISTRY]</a> and <a data-link-type="biblio" href="#biblio-ipv6-registry">[IPV6-REGISTRY]</a>). To determine the <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①">address space</a> of a given IP address
-  (<var>address</var>), run the following steps:</p>
+  the IANA Special-Purpose Address Registries (<a data-link-type="biblio" href="#biblio-ipv4-registry">[IPV4-REGISTRY]</a> and <a data-link-type="biblio" href="#biblio-ipv6-registry">[IPV6-REGISTRY]</a>). To determine the <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①">IP address space</a> of a given IP
+  address (<var>address</var>), run the following steps:</p>
     <ol>
      <li data-md>
       <p>If <var>address</var> is an <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-ipv4" id="ref-for-concept-ipv4">IPv4 address</a> in the "Loopback" address block
@@ -2178,19 +2178,19 @@ Location: https://sekrits/super-sekrit-project-with-super-sekrit-partner
     <p>For convenience, we additionally define the following terms:</p>
     <ol>
      <li data-md>
-      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="local-address">local address</dfn> is an IP address whose <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space③">address space</a> is <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local③">local</a>.</p>
+      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="local-address">local address</dfn> is an IP address whose <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space③">IP address space</a> is <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local③">local</a>.</p>
      <li data-md>
-      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="private-address">private address</dfn> is an IP address whose <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space④">address space</a> is <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private④">private</a>.</p>
+      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="private-address">private address</dfn> is an IP address whose <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space④">IP address space</a> is <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private④">private</a>.</p>
      <li data-md>
-      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="public-address">public address</dfn> is an IP address whose <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space⑤">address space</a> is <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public②">public</a>.</p>
+      <p>A <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport id="public-address">public address</dfn> is an IP address whose <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space⑤">IP address space</a> is <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public②">public</a>.</p>
     </ol>
     <h3 class="heading settled" data-level="2.2" id="private-network-request-heading"><span class="secno">2.2. </span><span class="content">Private Network Request</span><a class="self-link" href="#private-network-request-heading"></a></h3>
     <p>A <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request">request</a> (<var>request</var>) is a <dfn class="dfn-paneled" data-dfn-type="dfn" data-export id="private-network-request">private network request</dfn> if any of the following are true:</p>
     <ol>
      <li data-md>
-      <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current url</a>'s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host">host</a></code> maps to a <a data-link-type="dfn" href="#private-address" id="ref-for-private-address①">private address</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a>'s <a data-link-type="dfn" href="#environment-settings-object-address-space" id="ref-for-environment-settings-object-address-space">address space</a> is <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public③">public</a>.</p>
+      <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url">current url</a>'s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host">host</a></code> maps to a <a data-link-type="dfn" href="#private-address" id="ref-for-private-address①">private address</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client">client</a>'s <a data-link-type="dfn" href="#environment-settings-object-ip-address-space" id="ref-for-environment-settings-object-ip-address-space">IP address space</a> is <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public③">public</a>.</p>
      <li data-md>
-      <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current url</a>'s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host①">host</a></code> maps to a <a data-link-type="dfn" href="#local-address" id="ref-for-local-address">local address</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">client</a>'s <a data-link-type="dfn" href="#environment-settings-object-address-space" id="ref-for-environment-settings-object-address-space①">address space</a> is either <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public④">public</a> or <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private⑤">private</a>.</p>
+      <p><var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-current-url" id="ref-for-concept-request-current-url①">current url</a>'s <code class="idl"><a data-link-type="idl" href="https://url.spec.whatwg.org/#dom-url-host" id="ref-for-dom-url-host①">host</a></code> maps to a <a data-link-type="dfn" href="#local-address" id="ref-for-local-address">local address</a>, and <var>request</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client①">client</a>'s <a data-link-type="dfn" href="#environment-settings-object-ip-address-space" id="ref-for-environment-settings-object-ip-address-space①">IP address space</a> is either <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public④">public</a> or <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private⑤">private</a>.</p>
     </ol>
     <h3 class="heading settled" data-level="2.3" id="headers"><span class="secno">2.3. </span><span class="content">Additional CORS Headers</span><a class="self-link" href="#headers"></a></h3>
     <p>The <dfn class="dfn-paneled" data-dfn-type="http-header" data-export id="http-headerdef-access-control-request-private-network"><code>Access-Control-Request-Private-Network</code></dfn> indicates that the <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request①">request</a> is a <a data-link-type="dfn" href="#private-network-request" id="ref-for-private-network-request">private network request</a>.</p>
@@ -2212,7 +2212,7 @@ directive-value = ""
   a <code>policy</code> (<var>policy</var>):</p>
     <ol>
      <li data-md>
-      <p>Set <var>context</var>’s <a data-link-type="dfn" href="#environment-settings-object-address-space" id="ref-for-environment-settings-object-address-space②">address space</a> to <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public⑤">public</a> if <var>policy</var>’s <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#policy-disposition" id="ref-for-policy-disposition">disposition</a> is
+      <p>Set <var>context</var>’s <a data-link-type="dfn" href="#environment-settings-object-ip-address-space" id="ref-for-environment-settings-object-ip-address-space②">IP address space</a> to <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public⑤">public</a> if <var>policy</var>’s <a data-link-type="dfn" href="https://w3c.github.io/webappsec-csp/#policy-disposition" id="ref-for-policy-disposition">disposition</a> is
   "<code>enforce</code>".</p>
     </ol>
     <h3 class="heading settled" data-level="2.5" id="feature-detect"><span class="secno">2.5. </span><span class="content">Feature Detection</span><a class="self-link" href="#feature-detect"></a></h3>
@@ -2228,7 +2228,7 @@ directive-value = ""
   <c- b>readonly</c-> <c- b>attribute</c-> <a data-link-type="idl-name" href="#enumdef-addressspace" id="ref-for-enumdef-addressspace①"><c- n>AddressSpace</c-></a> <dfn class="idl-code" data-dfn-for="WorkerGlobalScope" data-dfn-type="attribute" data-export data-readonly data-type="AddressSpace" id="dom-workerglobalscope-addressspace"><code><c- g>addressSpace</c-></code><a class="self-link" href="#dom-workerglobalscope-addressspace"></a></dfn>;
 };
 </pre>
-    <p>Both attributes' getters return the value of the corresponding <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code>'s <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space">address space</a> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope②">WorkerGlobalScope</a></code>'s <a data-link-type="dfn" href="#workerglobalscope-address-space" id="ref-for-workerglobalscope-address-space">address space</a> property.</p>
+    <p>Both attributes' getters return the value of the corresponding <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document②">Document</a></code>'s <a data-link-type="dfn" href="#document-ip-address-space" id="ref-for-document-ip-address-space">IP address space</a> or <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope②">WorkerGlobalScope</a></code>'s <a data-link-type="dfn" href="#workerglobalscope-ip-address-space" id="ref-for-workerglobalscope-ip-address-space">IP address space</a> property.</p>
    </section>
    <section>
     <h2 class="heading settled" data-level="3" id="integrations"><span class="secno">3. </span><span class="content">Integrations</span><a class="self-link" href="#integrations"></a></h2>
@@ -2242,8 +2242,8 @@ directive-value = ""
   implications:</p>
     <ol>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">Requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a>'s <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space⑥">address space</a> is <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local④">local</a> are unchanged from status quo. They may
-  continue to make requests to IP addresses in any <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space⑦">address space</a> as
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request②">Requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client②">client</a>'s <a data-link-type="dfn" href="#environment-settings-object-ip-address-space" id="ref-for-environment-settings-object-ip-address-space③">IP address space</a> is <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local④">local</a> are unchanged from status quo. They may
+  continue to make requests to IP addresses in any <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space⑥">IP address space</a> as
   they do today.</p>
       <p class="issue" id="issue-207ba0b9"><a class="self-link" href="#issue-207ba0b9"></a> Chris Palmer suggests that we might want
   to change the proposal such that private services must always opt-in to
@@ -2251,11 +2251,11 @@ directive-value = ""
   preflight for all cross-origin requests to private servers, whether they
   come from public addresses, or private addresses. <a href="https://github.com/wicg/cors-rfc1918/issues/1">&lt;https://github.com/wicg/cors-rfc1918/issues/1></a></p>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">Requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">client</a>'s <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space⑧">address space</a> is <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private⑥">private</a> are allowed to fetch resources from <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private⑦">private</a> and <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public⑥">public</a> addresses as
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request③">Requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client③">client</a>'s <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space⑦">IP address space</a> is <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private⑥">private</a> are allowed to fetch resources from <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private⑦">private</a> and <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public⑥">public</a> addresses as
   they do today, but may only request <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local⑤">local</a> resources
   if their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client④">client</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context" id="ref-for-secure-context">secure context</a> <strong>and</strong> a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-preflight-request" id="ref-for-cors-preflight-request⑤">CORS-preflight request</a> to the target origin is successful.</p>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">Requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑤">client</a>'s <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space⑨">address space</a> is <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public⑦">public</a> are allowed to fetch resources from <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public⑧">public</a> addresses as they do today, but may only
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request" id="ref-for-concept-request④">Requests</a> whose <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑤">client</a>'s <a data-link-type="dfn" href="#environment-settings-object-ip-address-space" id="ref-for-environment-settings-object-ip-address-space④">IP address space</a> is <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public⑦">public</a> are allowed to fetch resources from <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public⑧">public</a> addresses as they do today, but may only
   request <a data-link-type="dfn" href="#ip-address-space-private" id="ref-for-ip-address-space-private⑧">private</a> and <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local⑥">local</a> resources if their <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-request-client" id="ref-for-concept-request-client⑥">client</a> is a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context" id="ref-for-secure-context①">secure context</a> <em>and</em> a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#cors-preflight-request" id="ref-for-cors-preflight-request⑥">CORS-preflight request</a> to the target origin is successful.</p>
     </ol>
     <p class="note" role="note"><span>Note:</span> UAs must not allow <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#secure-context" id="ref-for-secure-context②">non-secure</a> <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public⑨">public</a> contexts to request resources from <a data-link-type="dfn" href="#private-address" id="ref-for-private-address③">private addresses</a>, even if the private server would opt-in to such a
@@ -2265,16 +2265,16 @@ directive-value = ""
     <p>To those ends:</p>
     <ol>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-connection" id="ref-for-concept-connection">Connection</a> objects are given a new <dfn class="dfn-paneled" data-dfn-for="connection" data-dfn-type="dfn" data-export id="connection-address-space">address space</dfn>, whose value is the <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①⓪">IP address space</a> to which the connection’s remote endpoint belongs.
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-connection" id="ref-for-concept-connection">Connection</a> objects are given a new <dfn class="dfn-paneled" data-dfn-for="connection" data-dfn-type="dfn" data-export id="connection-ip-address-space">IP address space</dfn>, whose value is the <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space⑧">IP address space</a> to which the connection’s remote endpoint belongs.
   This applies to WebSocket connections too.</p>
      <li data-md>
-      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">Response</a> objects are given a new <dfn class="dfn-paneled" data-dfn-for="response" data-dfn-type="dfn" data-export id="response-address-space">address space</dfn> property, whose value is
-  an <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①①">IP address space</a>, initially null.</p>
+      <p><a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response" id="ref-for-concept-response">Response</a> objects are given a new <dfn class="dfn-paneled" data-dfn-for="response" data-dfn-type="dfn" data-export id="response-ip-address-space">IP address space</dfn> property, whose value is
+  an <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space⑨">IP address space</a>, initially null.</p>
      <li data-md>
       <p>The <a data-link-type="abstract-op" href="https://fetch.spec.whatwg.org/#concept-http-network-fetch" id="ref-for-concept-http-network-fetch">HTTP-network fetch</a> algorithm is amended to add a new step in
   between steps 7.1 and 7.2, after successfully obtaining a connection:</p>
       <blockquote>
-       <p>7.2. Set <var>response</var>’s <a data-link-type="dfn" href="#response-address-space" id="ref-for-response-address-space">address space</a> to <var>connection</var>’s <a data-link-type="dfn" href="#connection-address-space" id="ref-for-connection-address-space">address space</a>.</p>
+       <p>7.2. Set <var>response</var>’s <a data-link-type="dfn" href="#response-ip-address-space" id="ref-for-response-ip-address-space">IP address space</a> to <var>connection</var>’s <a data-link-type="dfn" href="#connection-ip-address-space" id="ref-for-connection-ip-address-space">IP address space</a>.</p>
       </blockquote>
      <li data-md>
       <p>The <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-http-fetch" id="ref-for-concept-http-fetch">HTTP fetch</a> algorithm should be adjusted to ensure that a
@@ -2385,34 +2385,34 @@ directive-value = ""
   beyond that and require a preflight. Not sure what the capabilities of the GET are, and how much
   control the caller has.</p>
     <h3 class="heading settled" data-level="3.3" id="integration-html"><span class="secno">3.3. </span><span class="content">Integration with HTML</span><a class="self-link" href="#integration-html"></a></h3>
-    <p>To support the checks in <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>, user agents must remember the source <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①②">address space</a> of contexts in which network requests are made. To this
+    <p>To support the checks in <a data-link-type="biblio" href="#biblio-fetch">[FETCH]</a>, user agents must remember the source <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①⓪">IP address space</a> of contexts in which network requests are made. To this
   effect, the <a data-link-type="biblio" href="#biblio-html">[HTML]</a> specification is patched as follows:</p>
     <ol>
      <li data-md>
-      <p>An <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①③">address space</a> property is persisted on a number of objects:</p>
+      <p>An <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①①">IP address space</a> property is persisted on a number of objects:</p>
       <ol>
        <li data-md>
-        <p><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code> objects are given an <dfn class="dfn-paneled" data-dfn-for="Document" data-dfn-type="dfn" data-export id="document-address-space">address space</dfn> property, whose value
-  is an <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①④">IP address space</a>.</p>
+        <p><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document③">Document</a></code> objects are given an <dfn class="dfn-paneled" data-dfn-for="Document" data-dfn-type="dfn" data-export id="document-ip-address-space">IP address space</dfn> property, whose
+  value is an <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①②">IP address space</a>.</p>
        <li data-md>
-        <p><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope③">WorkerGlobalScope</a></code> objects are given an <dfn class="dfn-paneled" data-dfn-for="WorkerGlobalScope" data-dfn-type="dfn" data-export id="workerglobalscope-address-space">address space</dfn> property,
-  whose value is an <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①⑤">IP address space</a>.</p>
+        <p><code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope③">WorkerGlobalScope</a></code> objects are given an <dfn class="dfn-paneled" data-dfn-for="WorkerGlobalScope" data-dfn-type="dfn" data-export id="workerglobalscope-ip-address-space">IP address space</dfn> property,
+  whose value is an <a data-link-type="dfn" href="#ip-address-space" id="ref-for-ip-address-space①③">IP address space</a>.</p>
        <li data-md>
-        <p>[[Environment settings objects]] are given an <dfn class="dfn-paneled" data-dfn-for="environment settings object" data-dfn-type="dfn" data-export id="environment-settings-object-address-space">address space</dfn> accessor, which has the following implementations:</p>
+        <p><a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object" id="ref-for-environment-settings-object①">Environment settings objects</a> are given an <dfn class="dfn-paneled" data-dfn-for="environment settings object" data-dfn-type="dfn" data-export id="environment-settings-object-ip-address-space">IP address space</dfn> accessor, which has the following implementations:</p>
         <ol>
          <li data-md>
-          <p>For <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window">Window</a></code> objects: return the <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space①">address space</a> of <var>window</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window">associated Document</a>.</p>
+          <p>For <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/window-object.html#window" id="ref-for-window">Window</a></code> objects: return the <a data-link-type="dfn" href="#document-ip-address-space" id="ref-for-document-ip-address-space①">IP address space</a> of <var>window</var>’s <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/window-object.html#concept-document-window" id="ref-for-concept-document-window">associated Document</a>.</p>
          <li data-md>
-          <p>For <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope④">WorkerGlobalScope</a></code> objects: return <var>worker global scope</var>’s <a data-link-type="dfn" href="#workerglobalscope-address-space" id="ref-for-workerglobalscope-address-space①">address space</a>.</p>
+          <p>For <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope④">WorkerGlobalScope</a></code> objects: return <var>worker global scope</var>’s <a data-link-type="dfn" href="#workerglobalscope-ip-address-space" id="ref-for-workerglobalscope-ip-address-space①">IP address space</a>.</p>
         </ol>
       </ol>
      <li data-md>
       <p>The <a data-link-type="abstract-op" href="https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-browsing-context" id="ref-for-creating-a-new-browsing-context">create a new browsing context</a> algorithm is amended with an extra
-  step in between the existing steps 19 and 20. Thus the initial <code>about:blank</code> document inherits its creator’s <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space②">address space</a>:</p>
+  step in between the existing steps 19 and 20. Thus the initial <code>about:blank</code> document inherits its creator’s <a data-link-type="dfn" href="#document-ip-address-space" id="ref-for-document-ip-address-space②">IP address space</a>:</p>
       <blockquote>
        <ol start="20">
         <li data-md>
-         <p>If <var>creator</var> is non-null, then set <var>document</var>’s <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space③">address space</a> to to <var>creator</var>’s <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space④">address space</a>.</p>
+         <p>If <var>creator</var> is non-null, then set <var>document</var>’s <a data-link-type="dfn" href="#document-ip-address-space" id="ref-for-document-ip-address-space③">IP address space</a> to to <var>creator</var>’s <a data-link-type="dfn" href="#document-ip-address-space" id="ref-for-document-ip-address-space④">IP address space</a>.</p>
        </ol>
       </blockquote>
      <li data-md>
@@ -2421,7 +2421,7 @@ directive-value = ""
       <blockquote>
        <ol start="12">
         <li data-md>
-         <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space⑤">address space</a> to <var>response</var>’s <a data-link-type="dfn" href="#response-address-space" id="ref-for-response-address-space①">address space</a>.</p>
+         <p>Set <var>document</var>’s <a data-link-type="dfn" href="#document-ip-address-space" id="ref-for-document-ip-address-space⑤">IP address space</a> to <var>response</var>’s <a data-link-type="dfn" href="#response-ip-address-space" id="ref-for-response-ip-address-space①">IP address space</a>.</p>
        </ol>
       </blockquote>
      <li data-md>
@@ -2429,8 +2429,8 @@ directive-value = ""
   the existing steps 14.4 and 14.5, after the new <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/multipage/workers.html#workerglobalscope" id="ref-for-workerglobalscope⑤">WorkerGlobalScope</a></code>'s
   referrer policy is set:</p>
       <blockquote>
-       <p>14.5. If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">url</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme">local scheme</a>, then set <var>worker global scope</var>’s <a data-link-type="dfn" href="#workerglobalscope-address-space" id="ref-for-workerglobalscope-address-space②">address space</a> to <var>owner</var>’s <a data-link-type="dfn" href="#workerglobalscope-address-space" id="ref-for-workerglobalscope-address-space③">address space</a>.
-14.5. Otherwise, set <var>worker global scope</var>’s <a data-link-type="dfn" href="#workerglobalscope-address-space" id="ref-for-workerglobalscope-address-space④">address space</a> to <var>response</var>’s <a data-link-type="dfn" href="#response-address-space" id="ref-for-response-address-space②">address space</a>.</p>
+       <p>14.5. If <var>response</var>’s <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#concept-response-url" id="ref-for-concept-response-url">url</a>'s <a data-link-type="dfn" href="https://url.spec.whatwg.org/#concept-url-scheme" id="ref-for-concept-url-scheme">scheme</a> is a <a data-link-type="dfn" href="https://fetch.spec.whatwg.org/#local-scheme" id="ref-for-local-scheme">local scheme</a>, then set <var>worker global scope</var>’s <a data-link-type="dfn" href="#workerglobalscope-ip-address-space" id="ref-for-workerglobalscope-ip-address-space②">IP address space</a> to <var>owner</var>’s <a data-link-type="dfn" href="#workerglobalscope-ip-address-space" id="ref-for-workerglobalscope-ip-address-space③">IP address space</a>.
+14.5. Otherwise, set <var>worker global scope</var>’s <a data-link-type="dfn" href="#workerglobalscope-ip-address-space" id="ref-for-workerglobalscope-ip-address-space④">IP address space</a> to <var>response</var>’s <a data-link-type="dfn" href="#response-ip-address-space" id="ref-for-response-ip-address-space②">IP address space</a>.</p>
       </blockquote>
     </ol>
     <p class="issue" id="issue-4a460a34"><a class="self-link" href="#issue-4a460a34"></a> Find a place to insert address space inheritance
@@ -2438,12 +2438,12 @@ directive-value = ""
     <p class="issue" id="issue-a7434e9a"><a class="self-link" href="#issue-a7434e9a"></a> Capture the address space of the URL creator
   when <code>createObjectUrl()</code> is called on a blob, and inherit that when loading
   a document from the resulting URL. <a href="https://github.com/WICG/cors-rfc1918/issues/27">&lt;https://github.com/WICG/cors-rfc1918/issues/27></a></p>
-    <div class="example" id="example-2a60f30e">
-     <a class="self-link" href="#example-2a60f30e"></a> Assuming that <code>example.com</code> resolves to a <a data-link-type="dfn" href="#public-address" id="ref-for-public-address⑤">public address</a> (say, <code>123.123.123.123</code>), then the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code> created when navigating to <code>https://example.com/document.html</code> will have its <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space⑥">address space</a> property set to <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public①⓪">public</a>. 
+    <div class="example" id="example-6214f0f4">
+     <a class="self-link" href="#example-6214f0f4"></a> Assuming that <code>example.com</code> resolves to a <a data-link-type="dfn" href="#public-address" id="ref-for-public-address⑤">public address</a> (say, <code>123.123.123.123</code>), then the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑤">Document</a></code> created when navigating to <code>https://example.com/document.html</code> will have its <a data-link-type="dfn" href="#document-ip-address-space" id="ref-for-document-ip-address-space⑥">IP address space</a> property set to <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public①⓪">public</a>. 
      <p>If this <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑥">Document</a></code> then embeds an <code>about:srcdoc</code> iframe, then the child
-    frame’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code> will have its <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space⑦">address space</a> property set
-    to <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public①①">public</a>.</p>
-     <p>If, on the other hand, <code>example.com</code> resolved to a <a data-link-type="dfn" href="#local-address" id="ref-for-local-address①">local address</a> (say, <code>127.0.0.1</code>), then the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑧">Document</a></code> created when navigating to <code>https://example.com/document.html</code> will have its <a data-link-type="dfn" href="#document-address-space" id="ref-for-document-address-space⑧">address space</a> property set to "<code>local</code>".</p>
+    frame’s <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑦">Document</a></code> will have its <a data-link-type="dfn" href="#document-ip-address-space" id="ref-for-document-ip-address-space⑦">IP address space</a> property
+    set to <a data-link-type="dfn" href="#ip-address-space-public" id="ref-for-ip-address-space-public①①">public</a>.</p>
+     <p>If, on the other hand, <code>example.com</code> resolved to a <a data-link-type="dfn" href="#local-address" id="ref-for-local-address①">local address</a> (say, <code>127.0.0.1</code>), then the <code class="idl"><a data-link-type="idl" href="https://html.spec.whatwg.org/#document" id="ref-for-document⑧">Document</a></code> created when navigating to <code>https://example.com/document.html</code> will have its <a data-link-type="dfn" href="#document-ip-address-space" id="ref-for-document-ip-address-space⑧">IP address space</a> property set to <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local⑦">local</a>.</p>
     </div>
    </section>
    <section>
@@ -2453,7 +2453,7 @@ directive-value = ""
   outlined above. It would be nice to prevent folks from harming themselves by
   opening a malicious HTML file locally, on the one hand, but on the other, code
   running locally is somewhat outside of any sane threat model.</p>
-    <p>For the moment, let’s err on the side of treating <code>file</code> URLs as <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local⑦">local</a>, as they seem to be just as much a part of the local
+    <p>For the moment, let’s err on the side of treating <code>file</code> URLs as <a data-link-type="dfn" href="#ip-address-space-local" id="ref-for-ip-address-space-local⑧">local</a>, as they seem to be just as much a part of the local
   system as anything else on a loopback address.</p>
     <p class="issue" id="issue-5f05c8e3"><a class="self-link" href="#issue-5f05c8e3"></a> Reevaluate this after implementation experience.</p>
    </section>
@@ -2651,16 +2651,7 @@ directive-value = ""
   <ul class="index">
    <li><a href="#http-headerdef-access-control-allow-private-network">Access-Control-Allow-Private-Network</a><span>, in §2.3</span>
    <li><a href="#http-headerdef-access-control-request-private-network">Access-Control-Request-Private-Network</a><span>, in §2.3</span>
-   <li>
-    address space
-    <ul>
-     <li><a href="#ip-address-space">definition of</a><span>, in §2.1</span>
-     <li><a href="#document-address-space">dfn for Document</a><span>, in §3.3</span>
-     <li><a href="#workerglobalscope-address-space">dfn for WorkerGlobalScope</a><span>, in §3.3</span>
-     <li><a href="#connection-address-space">dfn for connection</a><span>, in §3.1</span>
-     <li><a href="#environment-settings-object-address-space">dfn for environment settings object</a><span>, in §3.3</span>
-     <li><a href="#response-address-space">dfn for response</a><span>, in §3.1</span>
-    </ul>
+   <li><a href="#ip-address-space">address space</a><span>, in §2.1</span>
    <li><a href="#enumdef-addressspace">AddressSpace</a><span>, in §2.5</span>
    <li>
     addressSpace
@@ -2668,7 +2659,16 @@ directive-value = ""
      <li><a href="#dom-document-addressspace">attribute for Document</a><span>, in §2.5</span>
      <li><a href="#dom-workerglobalscope-addressspace">attribute for WorkerGlobalScope</a><span>, in §2.5</span>
     </ul>
-   <li><a href="#ip-address-space">IP address space</a><span>, in §2.1</span>
+   <li>
+    IP address space
+    <ul>
+     <li><a href="#ip-address-space">definition of</a><span>, in §2.1</span>
+     <li><a href="#document-ip-address-space">dfn for Document</a><span>, in §3.3</span>
+     <li><a href="#workerglobalscope-ip-address-space">dfn for WorkerGlobalScope</a><span>, in §3.3</span>
+     <li><a href="#connection-ip-address-space">dfn for connection</a><span>, in §3.1</span>
+     <li><a href="#environment-settings-object-ip-address-space">dfn for environment settings object</a><span>, in §3.3</span>
+     <li><a href="#response-ip-address-space">dfn for response</a><span>, in §3.1</span>
+    </ul>
    <li><a href="#dom-addressspace-local">"local"</a><span>, in §2.5</span>
    <li><a href="#ip-address-space-local">local</a><span>, in §2.1</span>
    <li><a href="#local-address">local address</a><span>, in §2.1</span>
@@ -2900,6 +2900,7 @@ directive-value = ""
    <a href="https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object">https://html.spec.whatwg.org/multipage/webappapis.html#environment-settings-object</a><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-environment-settings-object">2.4. The treat-as-public-address Content Security Policy Directive</a>
+    <li><a href="#ref-for-environment-settings-object①">3.3. Integration with HTML</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="term-for-initialise-the-document-object">
@@ -3095,8 +3096,8 @@ directive-value = ""
    <b><a href="#ip-address-space">#ip-address-space</a></b><b>Referenced in:</b>
    <ul>
     <li><a href="#ref-for-ip-address-space">2.1. IP Address Space</a> <a href="#ref-for-ip-address-space①">(2)</a> <a href="#ref-for-ip-address-space②">(3)</a> <a href="#ref-for-ip-address-space③">(4)</a> <a href="#ref-for-ip-address-space④">(5)</a> <a href="#ref-for-ip-address-space⑤">(6)</a>
-    <li><a href="#ref-for-ip-address-space⑥">3.1. Integration with Fetch</a> <a href="#ref-for-ip-address-space⑦">(2)</a> <a href="#ref-for-ip-address-space⑧">(3)</a> <a href="#ref-for-ip-address-space⑨">(4)</a> <a href="#ref-for-ip-address-space①⓪">(5)</a> <a href="#ref-for-ip-address-space①①">(6)</a>
-    <li><a href="#ref-for-ip-address-space①②">3.3. Integration with HTML</a> <a href="#ref-for-ip-address-space①③">(2)</a> <a href="#ref-for-ip-address-space①④">(3)</a> <a href="#ref-for-ip-address-space①⑤">(4)</a>
+    <li><a href="#ref-for-ip-address-space⑥">3.1. Integration with Fetch</a> <a href="#ref-for-ip-address-space⑦">(2)</a> <a href="#ref-for-ip-address-space⑧">(3)</a> <a href="#ref-for-ip-address-space⑨">(4)</a>
+    <li><a href="#ref-for-ip-address-space①⓪">3.3. Integration with HTML</a> <a href="#ref-for-ip-address-space①①">(2)</a> <a href="#ref-for-ip-address-space①②">(3)</a> <a href="#ref-for-ip-address-space①③">(4)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="ip-address-space-local">
@@ -3104,7 +3105,8 @@ directive-value = ""
    <ul>
     <li><a href="#ref-for-ip-address-space-local">2.1. IP Address Space</a> <a href="#ref-for-ip-address-space-local①">(2)</a> <a href="#ref-for-ip-address-space-local②">(3)</a> <a href="#ref-for-ip-address-space-local③">(4)</a>
     <li><a href="#ref-for-ip-address-space-local④">3.1. Integration with Fetch</a> <a href="#ref-for-ip-address-space-local⑤">(2)</a> <a href="#ref-for-ip-address-space-local⑥">(3)</a>
-    <li><a href="#ref-for-ip-address-space-local⑦">4.1. Where do file URLs fit?</a>
+    <li><a href="#ref-for-ip-address-space-local⑦">3.3. Integration with HTML</a>
+    <li><a href="#ref-for-ip-address-space-local⑧">4.1. Where do file URLs fit?</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="ip-address-space-private">
@@ -3195,17 +3197,17 @@ directive-value = ""
     <li><a href="#ref-for-enumdef-addressspace">2.5. Feature Detection</a> <a href="#ref-for-enumdef-addressspace①">(2)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="connection-address-space">
-   <b><a href="#connection-address-space">#connection-address-space</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="connection-ip-address-space">
+   <b><a href="#connection-ip-address-space">#connection-ip-address-space</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-connection-address-space">3.1. Integration with Fetch</a>
+    <li><a href="#ref-for-connection-ip-address-space">3.1. Integration with Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="response-address-space">
-   <b><a href="#response-address-space">#response-address-space</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="response-ip-address-space">
+   <b><a href="#response-ip-address-space">#response-ip-address-space</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-response-address-space">3.1. Integration with Fetch</a>
-    <li><a href="#ref-for-response-address-space①">3.3. Integration with HTML</a> <a href="#ref-for-response-address-space②">(2)</a>
+    <li><a href="#ref-for-response-ip-address-space">3.1. Integration with Fetch</a>
+    <li><a href="#ref-for-response-ip-address-space①">3.3. Integration with HTML</a> <a href="#ref-for-response-ip-address-space②">(2)</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="cache-request-network-type">
@@ -3214,25 +3216,26 @@ directive-value = ""
     <li><a href="#ref-for-cache-request-network-type">3.1. Integration with Fetch</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="document-address-space">
-   <b><a href="#document-address-space">#document-address-space</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="document-ip-address-space">
+   <b><a href="#document-ip-address-space">#document-ip-address-space</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-document-address-space">2.5. Feature Detection</a>
-    <li><a href="#ref-for-document-address-space①">3.3. Integration with HTML</a> <a href="#ref-for-document-address-space②">(2)</a> <a href="#ref-for-document-address-space③">(3)</a> <a href="#ref-for-document-address-space④">(4)</a> <a href="#ref-for-document-address-space⑤">(5)</a> <a href="#ref-for-document-address-space⑥">(6)</a> <a href="#ref-for-document-address-space⑦">(7)</a> <a href="#ref-for-document-address-space⑧">(8)</a>
+    <li><a href="#ref-for-document-ip-address-space">2.5. Feature Detection</a>
+    <li><a href="#ref-for-document-ip-address-space①">3.3. Integration with HTML</a> <a href="#ref-for-document-ip-address-space②">(2)</a> <a href="#ref-for-document-ip-address-space③">(3)</a> <a href="#ref-for-document-ip-address-space④">(4)</a> <a href="#ref-for-document-ip-address-space⑤">(5)</a> <a href="#ref-for-document-ip-address-space⑥">(6)</a> <a href="#ref-for-document-ip-address-space⑦">(7)</a> <a href="#ref-for-document-ip-address-space⑧">(8)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="workerglobalscope-address-space">
-   <b><a href="#workerglobalscope-address-space">#workerglobalscope-address-space</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="workerglobalscope-ip-address-space">
+   <b><a href="#workerglobalscope-ip-address-space">#workerglobalscope-ip-address-space</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-workerglobalscope-address-space">2.5. Feature Detection</a>
-    <li><a href="#ref-for-workerglobalscope-address-space①">3.3. Integration with HTML</a> <a href="#ref-for-workerglobalscope-address-space②">(2)</a> <a href="#ref-for-workerglobalscope-address-space③">(3)</a> <a href="#ref-for-workerglobalscope-address-space④">(4)</a>
+    <li><a href="#ref-for-workerglobalscope-ip-address-space">2.5. Feature Detection</a>
+    <li><a href="#ref-for-workerglobalscope-ip-address-space①">3.3. Integration with HTML</a> <a href="#ref-for-workerglobalscope-ip-address-space②">(2)</a> <a href="#ref-for-workerglobalscope-ip-address-space③">(3)</a> <a href="#ref-for-workerglobalscope-ip-address-space④">(4)</a>
    </ul>
   </aside>
-  <aside class="dfn-panel" data-for="environment-settings-object-address-space">
-   <b><a href="#environment-settings-object-address-space">#environment-settings-object-address-space</a></b><b>Referenced in:</b>
+  <aside class="dfn-panel" data-for="environment-settings-object-ip-address-space">
+   <b><a href="#environment-settings-object-ip-address-space">#environment-settings-object-ip-address-space</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-environment-settings-object-address-space">2.2. Private Network Request</a> <a href="#ref-for-environment-settings-object-address-space①">(2)</a>
-    <li><a href="#ref-for-environment-settings-object-address-space②">2.4. The treat-as-public-address Content Security Policy Directive</a>
+    <li><a href="#ref-for-environment-settings-object-ip-address-space">2.2. Private Network Request</a> <a href="#ref-for-environment-settings-object-ip-address-space①">(2)</a>
+    <li><a href="#ref-for-environment-settings-object-ip-address-space②">2.4. The treat-as-public-address Content Security Policy Directive</a>
+    <li><a href="#ref-for-environment-settings-object-ip-address-space③">3.1. Integration with Fetch</a> <a href="#ref-for-environment-settings-object-ip-address-space④">(2)</a>
    </ul>
   </aside>
 <script>/* script-dfn-panel */

--- a/index.src.html
+++ b/index.src.html
@@ -23,12 +23,21 @@ spec: RFC1918; urlPrefix: https://tools.ietf.org/html/rfc1918
 spec: HTML; urlPrefix: https://html.spec.whatwg.org/
   type: interface
     text: Document; url: document;
+  type: abstract-op
+    text: create a new browsing context; url: multipage/browsers.html#creating-a-new-browsing-context
+    text: initialize the Document object; url: multipage/browsing-the-web.html#initialise-the-document-object
+    text: run a worker; url: multipage/workers.html#run-a-worker
+spec: HTML; urlPrefix: https://fetch.spec.whatwg.org/
+  type: abstract-op
+    text: HTTP-network fetch; url: #concept-http-network-fetch
 </pre>
 <pre class="link-defaults">
 spec:fetch; type:dfn; for:/; text:request
+spec:fetch; type:dfn; for:/; text:response
 spec:fetch; type:dfn; for:/; text:cors-preflight fetch
 spec:fetch; type:dfn; for:/; text:cors-preflight cache
 spec:fetch; type:dfn; for:/; text:establish a websocket connection
+spec:fetch; type:dfn; for:/; text:obtain a connection
 spec:fetch; type:dfn; for:cache; text:cache match
 </pre>
 <pre class="biblio">
@@ -124,9 +133,10 @@ spec:fetch; type:dfn; for:cache; text:cache match
 
   *   Users' routers, as outlined in [[SOHO-PHARMING]]. Note that status quo
       CORS protections don't protect against the kinds of attacks discussed here
-      as they rely only on <a>CORS-safelisted methods</a> and <a>CORS-safelisted request-headers</a>. No
-      preflight is triggered, and the attacker doesn't actually care about
-      reading the response, as the request itself is the CSRF attack.
+      as they rely only on [=CORS-safelisted methods=] and
+      [=CORS-safelisted request-headers=]. No preflight is triggered, and the
+      attacker doesn't actually care about reading the response, as the request
+      itself is the CSRF attack.
 
   *   Software running a web interface on a user's loopback address. For better
       or worse, this is becoming a common deployment mechanism for all manner of
@@ -158,8 +168,8 @@ spec:fetch; type:dfn; for:cache; text:cache match
 
     `router.local` will be resolved to the router's address via the magic of
     multicast DNS [[RFC6762]], and the user agent will note it as
-    <a>private</a>. Since `csrf.attack` resolved to a <a>public address</a>, the
-    request will trigger a <a>CORS-preflight request</a>:
+    [=IP address space/private=]. Since `csrf.attack` resolved to a
+    [=public address=], the request will trigger a [=CORS-preflight request=]:
 
 
     <pre>
@@ -195,9 +205,9 @@ spec:fetch; type:dfn; for:cache; text:cache match
     <a>CORS-preflight request</a>.
 
     When a website on the public internet makes a request to the device, the
-    user agent determines that the requestor is <a>public</a>, and the router
-    is <a>private</a>. This means that requests will trigger a <a>CORS-preflight
-    request</a>, just as above.
+    user agent determines that the requestor is [=IP address space/public=], and
+    the router is [=IP address space/private=]. This means that requests will
+    trigger a [=CORS-preflight request=], just as above.
 
     The device can explicitly grant access by sending the right headers in its
     response to the preflight request. For the above request, that might look
@@ -286,66 +296,72 @@ spec:fetch; type:dfn; for:cache; text:cache match
 <section>
   <h2 id="framework">Framework</h2>
 
-  <h3 id="address-space-heading">Address Space</h3>
+  <h3 id="ip-address-space-heading">IP Address Space</h3>
 
-  Every IP address belongs to an IP <dfn export>address space</dfn>, which can
-  be one of three different values:
+  Every IP address belongs to an
+  <dfn export local-lt="address space">IP address space</dfn>, which can be one
+  of three different values:
 
-  1.  <dfn for="address space" export>local</dfn>: contains the local host only.
-      In other words, addresses whose target differs for every device.
-  1.  <dfn for="address space" export>private</dfn>: contains addresses that
-      have meaning only within the current network. In other words, addresses
-      whose target differs based on network position.
-  1.  <dfn for="address space" export>public</dfn>: contains all other
-      addresses. In other words, addresses whose target is the same for all
-      devices globally on the IP network.
+  1.  <dfn for="IP address space" export>local</dfn>: contains the local
+      host only. In other words, addresses whose target differs for every
+      device.
+  1.  <dfn for="IP address space" export>private</dfn>: contains
+      addresses that have meaning only within the current network. In other
+      words, addresses whose target differs based on network position.
+  1.  <dfn for="IP address space" export>public</dfn>: contains all
+      other addresses. In other words, addresses whose target is the same for
+      all devices globally on the IP network.
 
-  The contents of each [=address space=] are determined in accordance with the
-  IANA Special-Purpose Address Registries ([[IPV4-REGISTRY]] and
-  [[IPV6-REGISTRY]]). To determine the [=address space=] of a given IP address
+  The contents of each [=IP address space=] are determined in accordance with
+  the IANA Special-Purpose Address Registries ([[IPV4-REGISTRY]] and
+  [[IPV6-REGISTRY]]). To determine the [=/address space=] of a given IP address
   (|address|), run the following steps:
 
   1.  If |address| is an [=IPv4 address=] in the "Loopback" address block
-      (`127.0.0.1/8` at time of writing), then return [=address space/local=].
+      (`127.0.0.1/8` at time of writing), then return
+      [=IP address space/local=].
   1.  If |address| is an [=IPv6 address=] in the "Loopback Address" address
-      block (`::1/128` at time of writing), then return [=address space/local=].
+      block (`::1/128` at time of writing), then return
+      [=IP address space/local=].
   1.  If |address| is an IPv6 address in the "IPv4-mapped Address" address block
-      (`::ffff:0:0/96` at time of writing), return the [=address space=] of its
-      embedded IPv4 address.
+      (`::ffff:0:0/96` at time of writing), return the [=IP address space=] of
+      its embedded IPv4 address.
   1.  If |address| belongs to an address block for which the
       `Globally Reachable` bit is set to `False` in the relevant IANA registry,
-      then return [=address space/private=].
-  1.  Otherwise return [=address space/public=].
+      then return [=IP address space/private=].
+  1.  Otherwise return [=IP address space/public=].
 
   Note: Link-local IP addresses such as `169.254.0.0/16` are considered
-  [=address space/private=], since they can be shared among multiple devices on
-  a network link. A previous version of this specification considered them to be
-  [=address space/local=] instead.
+  [=IP address space/private=], since such addresses can identify the same
+  target for all devices on a network link. A previous version of this
+  specification considered them to be [=IP address space/local=] instead.
 
   ISSUE(wicg/cors-rfc1918#36): Remove the special case for IPv4-mapped IPv6
   addresses once access to these addresses is blocked entirely.
 
   For convenience, we additionally define the following terms:
 
-  1.  A <dfn>local address</dfn> is an address whose [=address space=] is
-      [=address space/local=].
-  1.  A <dfn>private address</dfn> is an address whose [=address space=] is
-      [=address space/private=].
-  1.  A <dfn>public address</dfn> is an address whose [=address space=] is
-      [=address space/public=].
+  1.  A <dfn>local address</dfn> is an IP address whose [=/address space=] is
+      [=IP address space/local=].
+  1.  A <dfn>private address</dfn> is an IP address whose [=/address space=] is
+      [=IP address space/private=].
+  1.  A <dfn>public address</dfn> is an IP address whose [=/address space=] is
+      [=IP address space/public=].
 
   <h3 id="private-network-request-heading">Private Network Request</h3>
 
-  A <a>request</a> (|request|) is a <dfn export>private network request</dfn>
+  A [=request=] (|request|) is a <dfn export>private network request</dfn>
   if any of the following are true:
 
-  1.  |request|'s <a for="request">current url</a>'s {{URL/host}} maps to a
-      <a>private address</a>, and |request|'s <a for="request">client</a>'s
-      <a>address space</a> is <a>public</a>.
+  1.  |request|'s [=request/current url=]'s {{URL/host}} maps to a
+      [=private address=], and |request|'s [=request/client=]'s
+      [=environment settings object/address space=] is
+      [=IP address space/public=].
       
-  1.  |request|'s <a for="request">current url</a>'s {{URL/host}} maps to a
-      <a>local address</a>, and |request|'s <a for="request">client</a>'s
-      <a>address space</a> is either <a>public</a> or <a>private</a>.
+  1.  |request|'s [=request/current url=]'s {{URL/host}} maps to a
+      [=local address=], and |request|'s [=request/client=]'s
+      [=environment settings object/address space=] is either
+      [=IP address space/public=] or [=IP address space/private=].
 
   <h3 id="headers">Additional CORS Headers</h3>
 
@@ -374,12 +390,13 @@ spec:fetch; type:dfn; for:cache; text:cache match
   delivered in a `Content-Security-Policy-Report-Only` header, or within
   a <{meta}> element.
 
-  This directive's <a>initialization</a> algorithm is as follows. Given a
-  `Document` or `global object` (|context|), a `Response` (|response|), and
+  This directive's [=initialization=] algorithm is as follows. Given an
+  [=environment settings object=] (|context|), a `Response` (|response|), and
   a `policy` (|policy|):
 
-  1.  Set |context|'s <a>address space</a> to "`public`" if |policy|'s
-      <a for="policy">disposition</a> is "`enforce`".
+  1.  Set |context|'s [=environment settings object/address space=] to
+      [=IP address space/public=] if |policy|'s [=policy/disposition=] is
+      "`enforce`".
 
   <h3 id="feature-detect">Feature Detection</h3>
   
@@ -398,8 +415,9 @@ spec:fetch; type:dfn; for:cache; text:cache match
     };
   </pre>
 
-  Both attributes' getters return the value of the corresponding {{Document}} or
-  {{WorkerGlobalScope}}'s <a>address space</a> property.
+  Both attributes' getters return the value of the corresponding {{Document}}'s
+  [=Document/address space=] or {{WorkerGlobalScope}}'s
+  [=WorkerGlobalScope/address space=] property.
 </section>
 
 <!-- Big Text: Integrations -->
@@ -418,9 +436,9 @@ spec:fetch; type:dfn; for:cache; text:cache match
   This document proposes a few changes to Fetch, with the following
   implications:
 
-  1.  <a>Requests</a> whose <a for="request">client</a>'s <a>address space</a>
-      is "`local`" are unchanged from status quo. They may continue to make
-      requests to <a>public</a>, <a>private</a>, and <a>local</a> addresses as
+  1.  [=Requests=] whose [=request/client=]'s [=/address space=]
+      is [=IP address space/local=] are unchanged from status quo. They may
+      continue to make requests to IP addresses in any [=/address space=] as
       they do today.
 
       ISSUE(wicg/cors-rfc1918#1): Chris Palmer suggests that we might want
@@ -429,29 +447,45 @@ spec:fetch; type:dfn; for:cache; text:cache match
       preflight for all cross-origin requests to private servers, whether they
       come from public addresses, or private addresses.
 
-  2.  <a>Requests</a> whose <a for="request">client</a>'s <a>address space</a>
-      is "`private`" are allowed to fetch resources from <a>private</a> and
-      <a>public</a> addresses as they do today, but may only request
-      <a>local</a> resources if their <a for="request">client</a> is a
-      <a>secure context</a> <em>and</em> a <a>CORS-preflight request</a> to the
-      target origin is successful.
+  2.  [=Requests=] whose [=request/client=]'s [=/address space=] is
+      [=IP address space/private=] are allowed to fetch resources from
+      [=IP address space/private=] and [=IP address space/public=] addresses as
+      they do today, but may only request [=IP address space/local=] resources
+      if their [=request/client=] is a [=secure context=] **and** a
+      [=CORS-preflight request=] to the target origin is successful.
 
-  3.  <a>Requests</a> whose <a for="request">client</a>'s <a>address space</a>
-      is "`public`" are allowed to fetch resources from <a>public</a> addresses
-      as they do today, but may only request <a>private</a> and <a>local</a>
-      resources if their <a for="request">client</a> is a <a>secure context</a>
-      <em>and</em> a <a>CORS-preflight request</a> to the target origin is
-      successful.
+  3.  [=Requests=] whose [=request/client=]'s [=/address space=]
+      is [=IP address space/public=] are allowed to fetch resources from
+      [=IP address space/public=] addresses as they do today, but may only
+      request [=IP address space/private=] and [=IP address space/local=]
+      resources if their [=request/client=] is a [=secure context=] <em>and</em>
+      a [=CORS-preflight request=] to the target origin is successful.
 
   Note: UAs must not allow <a lt="secure context">non-secure</a>
-  <a>public</a> contexts to request resources from <a>private
-  addresses</a>, even if the private server would opt-in to such a request via
-  a preflight. Making requests to <a>private</a> resources presents risks which
-  are mitigated by ensuring the integrity of the <a for="request">client</a>
-  which initiates the request. In particular, network attackers should not be
-  able to trivially exploit an endpoint's consent to a non-secure origin.
+  [=IP address space/public=] contexts to request resources from
+  [=private addresses=], even if the private server would opt-in to such a
+  request via a preflight. Making requests to [=IP address space/private=]
+  resources presents risks which are mitigated by ensuring the integrity of the
+  [=request/client=] which initiates the request. In particular, network
+  attackers should not be able to trivially exploit an endpoint's consent to a
+  non-secure origin.
 
   To those ends:
+
+  1.  [=Connection=] objects are given a new
+      <dfn export for="connection">address space</dfn>, whose value is the
+      [=IP address space=] to which the connection's remote endpoint belongs.
+      This applies to WebSocket connections too.
+
+  1.  [=Response=] objects are given a new
+      <dfn export for="response">address space</dfn> property, whose value is
+      an [=IP address space=], initially null.
+
+  1.  The [$HTTP-network fetch$] algorithm is amended to add a new step in
+      between steps 7.1 and 7.2, after successfully obtaining a connection:
+
+      > 7.2. Set <var ignore>response</var>'s [=response/address space=] to
+      >      <var ignore>connection</var>'s [=connection/address space=].
 
   1.  The <a>HTTP fetch</a> algorithm should be adjusted to ensure that a
       preflight is triggered for all <a>private network requests</a>. This might
@@ -474,7 +508,7 @@ spec:fetch; type:dfn; for:cache; text:cache match
       from a <a>public address</a> that targets a <a>private address</a>. This
       includes navigations.
 
-  2.  The <a>CORS-preflight fetch</a> algorithm should be adjusted to append
+  1.  The <a>CORS-preflight fetch</a> algorithm should be adjusted to append
       an <a http-header>`Access-Control-Request-Private-Network`</a> header for
       preflights triggered by <a>private network requests</a>. For instance, the
       following could be executed after the current step 5:
@@ -491,7 +525,7 @@ spec:fetch; type:dfn; for:cache; text:cache match
               "<a http-header>`Access-Control-Request-Private-Network`</a>" to
               "`true`" in |preflight|'s <a for="request">header list</a>.
 
-  3.  The <a>CORS-preflight fetch</a> algorithm should be further adjusted to
+  1.  The <a>CORS-preflight fetch</a> algorithm should be further adjusted to
       ensure that consent is explicitly granted via an appropriate
       "<a http-header>`Access-Control-Allow-Private-Network`</a>" header in the
       response. For instance, the following could be executed before the current
@@ -506,7 +540,7 @@ spec:fetch; type:dfn; for:cache; text:cache match
 
           2.  If |allow| is not "`true`", return a <a>network error</a>.
 
-  4.  Finally, to mitigate the impact of DNS rebinding attacks (see
+  1.  Finally, to mitigate the impact of DNS rebinding attacks (see
       [[#dns-rebinding]]), the <a>CORS-preflight cache</a> should be adjusted to
       distinguish between request types. For example, we could:
 
@@ -563,37 +597,81 @@ spec:fetch; type:dfn; for:cache; text:cache match
 
   <h3 id="integration-html">Integration with HTML</h3>
 
-  To support the checks in [[FETCH]], we store an
-  <dfn attribute for="Document">address space</dfn> property on
-  {{Document}} objects and a similar
-  <dfn attribute for="WorkerGlobalScope">address space</dfn> on
-  {{WorkerGlobalScope}} objects, which is set as follows during {{Document}} and
-  {{Worker}} initialization:
-  
-  1.  Set {{Document/address space}} to "`local`" if the resource used to
-      instantiate the {{Document}} or {{Worker}} was delivered from a
-      [=local address=], or from a URL whose [=url/scheme=] is "`file`" (see
-      [[#file-url]]).
+  To support the checks in [[FETCH]], user agents must remember the source
+  [=/address space=] of contexts in which network requests are made. To this
+  effect, the [[HTML]] specification is patched as follows:
 
-  2.  Set {{Document/address space}} to "`private`" if the resource
-      used to instantiate the {{Document}} or {{Worker}} was delivered
-      from a [=private address=].
+  1.  An [=/address space=] property is persisted on a number of objects:
 
-  3.  Set {{Document/address space}} to "`public`" if the resource
-      used to instantiate the {{Document}} or {{Worker}} was delivered
-      from a [=public address=].
+      1.  {{Document}} objects are given an
+          <dfn export for="Document">address space</dfn> property, whose value
+          is an [=IP address space=].
+
+      1.  {{WorkerGlobalScope}} objects are given an
+          <dfn export for="WorkerGlobalScope">address space</dfn> property,
+          whose value is an [=IP address space=].
+
+      1.  [[Environment settings objects]] are given an
+          <dfn export for="environment settings object">address space</dfn>
+          accessor, which has the following implementations:
+
+          1.  For {{Window}} objects: return the [=Document/address space=] of
+              <var ignore>window</var>'s [=associated Document=].
+
+          1.  For {{WorkerGlobalScope}} objects: return
+              <var ignore>worker global scope</var>'s
+              [=WorkerGlobalScope/address space=].
+
+  1.  The [$create a new browsing context$] algorithm is amended with an extra
+      step in between the existing steps 19 and 20. Thus the initial
+      `about:blank` document inherits its creator's [=Document/address space=]:
+
+      > 20.  If |creator| is non-null, then set <var ignore>document</var>'s
+      >      [=Document/address space=] to to |creator|'s
+      >      [=Document/address space=].
+
+  1.  The [$initialize the Document object$] algorithm is amended with an extra
+      step in between the existing steps 10 and 11, before the new
+      {{Document}}'s [=Document/CSP list=] is initialized:
+
+      > 12.  Set <var ignore>document</var>'s [=Document/address space=] to
+      >      <var ignore>response</var>'s [=response/address space=].
+
+  1.  The [$run a worker$] algorithm is amended with two extra steps in between
+      the existing steps 14.4 and 14.5, after the new {{WorkerGlobalScope}}'s
+      referrer policy is set:
+
+      > 14.5. If |response|'s [=response/url=]'s [=url/scheme=] is a
+      >       [=local scheme=], then set |worker global scope|'s
+      >       [=WorkerGlobalScope/address space=] to <var ignore>owner</var>'s
+      >       [=WorkerGlobalScope/address space=].
+      > 14.5. Otherwise, set |worker global scope|'s
+      >       [=WorkerGlobalScope/address space=] to |response|'s
+      >       [=response/address space=].
+
+  ISSUE(WICG/cors-rfc1918#27): Find a place to insert address space inheritance
+  from the navigation initiator for `data:` URLs.
+
+  ISSUE(WICG/cors-rfc1918#27): Capture the address space of the URL creator
+  when `createObjectUrl()` is called on a blob, and inherit that when loading
+  a document from the resulting URL.
 
   <div class="example">
-    Assuming that `example.com` resolves to a <a>public address</a> (say,
+    Assuming that `example.com` resolves to a [=public address=] (say,
     `123.123.123.123`), then the {{Document}} created when navigating to
-    `https://example.com/document.html` will have its {{Document/address space}}
-    property set to "`public`".
+    `https://example.com/document.html` will have its [=Document/address space=]
+    property set to [=IP address space/public=].
 
-    If, on the other hand, `example.com` resolved to a <a>local address</a>
+    If this {{Document}} then embeds an `about:srcdoc` iframe, then the child
+    frame's {{Document}} will have its [=Document/address space=] property set
+    to [=IP address space/public=].
+
+    If, on the other hand, `example.com` resolved to a [=local address=]
     (say, `127.0.0.1`), then the {{Document}} created when navigating to
-    `https://example.com/document.html` will have its {{Document/address space}}
+    `https://example.com/document.html` will have its [=Document/address space=]
     property set to "`local`".
   </div>
+
 </section>
 
 <section>
@@ -606,9 +684,9 @@ spec:fetch; type:dfn; for:cache; text:cache match
   opening a malicious HTML file locally, on the one hand, but on the other, code
   running locally is somewhat outside of any sane threat model.
 
-  For the moment, let's err on the side of treating `file` URLs as <a>local</a>,
-  as they seem to be just as much a part of the local system as anything else on
-  a loopback address.
+  For the moment, let's err on the side of treating `file` URLs as
+  [=IP address space/local=], as they seem to be just as much a part of the local
+  system as anything else on a loopback address.
 
   ISSUE: Reevaluate this after implementation experience.
 </section>
@@ -632,12 +710,13 @@ spec:fetch; type:dfn; for:cache; text:cache match
 
   Note that the CORS restrictions added by the proposal in this document do not
   obviate mixed content checks [[!MIXED-CONTENT]]. Developers who wish to
-  fetch <a>private</a> resources from <a>public</a> pages MUST ensure that the
-  connection is secure. This might involve a solution along the lines of
-  [[PLEX]], or we might end up inventing a new way of ensuring a secure
-  connection to devices (perhaps the pairing ceremony hinted at above, or one of
-  the ideas floated in [[SECURE-LOCAL-COMMUNICATION]]?). In either case,
-  consenting to access by sending proper CORS is necessary, but not sufficient.
+  fetch [=IP address space/private=] resources from [=IP address space/public=]
+  pages MUST ensure that the connection is secure. This might involve a solution
+  along the lines of [[PLEX]], or we might end up inventing a new way of
+  ensuring a secure connection to devices (perhaps the pairing ceremony hinted
+  at above, or one of the ideas floated in [[SECURE-LOCAL-COMMUNICATION]]?). In
+  either case, consenting to access by sending proper CORS is necessary, but not
+  sufficient.
 
   Note: Doing something like the proposal here would make me more comfortable
   with relaxing the mixed content restrictions that prohibit unencrypted

--- a/index.src.html
+++ b/index.src.html
@@ -655,7 +655,7 @@ spec:fetch; type:dfn; for:cache; text:cache match
   ISSUE(WICG/cors-rfc1918#27): Find a place to insert address space inheritance
   from the navigation initiator for `data:` URLs.
 
-  ISSUE(WICG/cors-rfc1918#27): Capture the address space of the URL creator
+  ISSUE(WICG/cors-rfc1918#18): Capture the address space of the URL creator
   when `createObjectUrl()` is called on a blob, and inherit that when loading
   a document from the resulting URL.
 

--- a/index.src.html
+++ b/index.src.html
@@ -312,10 +312,10 @@ spec:fetch; type:dfn; for:cache; text:cache match
       other addresses. In other words, addresses whose target is the same for
       all devices globally on the IP network.
 
-  The contents of each [=IP address space=] are determined in accordance with
+  The contents of each [=/IP address space=] are determined in accordance with
   the IANA Special-Purpose Address Registries ([[IPV4-REGISTRY]] and
-  [[IPV6-REGISTRY]]). To determine the [=/address space=] of a given IP address
-  (|address|), run the following steps:
+  [[IPV6-REGISTRY]]). To determine the [=/IP address space=] of a given IP
+  address (|address|), run the following steps:
 
   1.  If |address| is an [=IPv4 address=] in the "Loopback" address block
       (`127.0.0.1/8` at time of writing), then return
@@ -324,7 +324,7 @@ spec:fetch; type:dfn; for:cache; text:cache match
       block (`::1/128` at time of writing), then return
       [=IP address space/local=].
   1.  If |address| is an IPv6 address in the "IPv4-mapped Address" address block
-      (`::ffff:0:0/96` at time of writing), return the [=IP address space=] of
+      (`::ffff:0:0/96` at time of writing), return the [=/IP address space=] of
       its embedded IPv4 address.
   1.  If |address| belongs to an address block for which the
       `Globally Reachable` bit is set to `False` in the relevant IANA registry,
@@ -341,12 +341,12 @@ spec:fetch; type:dfn; for:cache; text:cache match
 
   For convenience, we additionally define the following terms:
 
-  1.  A <dfn>local address</dfn> is an IP address whose [=/address space=] is
+  1.  A <dfn>local address</dfn> is an IP address whose [=/IP address space=] is
       [=IP address space/local=].
-  1.  A <dfn>private address</dfn> is an IP address whose [=/address space=] is
-      [=IP address space/private=].
-  1.  A <dfn>public address</dfn> is an IP address whose [=/address space=] is
-      [=IP address space/public=].
+  1.  A <dfn>private address</dfn> is an IP address whose [=/IP address space=]
+      is [=IP address space/private=].
+  1.  A <dfn>public address</dfn> is an IP address whose [=/IP address space=]
+      is [=IP address space/public=].
 
   <h3 id="private-network-request-heading">Private Network Request</h3>
 
@@ -355,12 +355,12 @@ spec:fetch; type:dfn; for:cache; text:cache match
 
   1.  |request|'s [=request/current url=]'s {{URL/host}} maps to a
       [=private address=], and |request|'s [=request/client=]'s
-      [=environment settings object/address space=] is
+      [=environment settings object/IP address space=] is
       [=IP address space/public=].
       
   1.  |request|'s [=request/current url=]'s {{URL/host}} maps to a
       [=local address=], and |request|'s [=request/client=]'s
-      [=environment settings object/address space=] is either
+      [=environment settings object/IP address space=] is either
       [=IP address space/public=] or [=IP address space/private=].
 
   <h3 id="headers">Additional CORS Headers</h3>
@@ -394,7 +394,7 @@ spec:fetch; type:dfn; for:cache; text:cache match
   [=environment settings object=] (|context|), a `Response` (|response|), and
   a `policy` (|policy|):
 
-  1.  Set |context|'s [=environment settings object/address space=] to
+  1.  Set |context|'s [=environment settings object/IP address space=] to
       [=IP address space/public=] if |policy|'s [=policy/disposition=] is
       "`enforce`".
 
@@ -416,8 +416,8 @@ spec:fetch; type:dfn; for:cache; text:cache match
   </pre>
 
   Both attributes' getters return the value of the corresponding {{Document}}'s
-  [=Document/address space=] or {{WorkerGlobalScope}}'s
-  [=WorkerGlobalScope/address space=] property.
+  [=Document/IP address space=] or {{WorkerGlobalScope}}'s
+  [=WorkerGlobalScope/IP address space=] property.
 </section>
 
 <!-- Big Text: Integrations -->
@@ -436,9 +436,10 @@ spec:fetch; type:dfn; for:cache; text:cache match
   This document proposes a few changes to Fetch, with the following
   implications:
 
-  1.  [=Requests=] whose [=request/client=]'s [=/address space=]
-      is [=IP address space/local=] are unchanged from status quo. They may
-      continue to make requests to IP addresses in any [=/address space=] as
+  1.  [=Requests=] whose [=request/client=]'s
+      [=environment settings object/IP address space=] is
+      [=IP address space/local=] are unchanged from status quo. They may
+      continue to make requests to IP addresses in any [=/IP address space=] as
       they do today.
 
       ISSUE(wicg/cors-rfc1918#1): Chris Palmer suggests that we might want
@@ -447,15 +448,16 @@ spec:fetch; type:dfn; for:cache; text:cache match
       preflight for all cross-origin requests to private servers, whether they
       come from public addresses, or private addresses.
 
-  2.  [=Requests=] whose [=request/client=]'s [=/address space=] is
+  2.  [=Requests=] whose [=request/client=]'s [=/IP address space=] is
       [=IP address space/private=] are allowed to fetch resources from
       [=IP address space/private=] and [=IP address space/public=] addresses as
       they do today, but may only request [=IP address space/local=] resources
       if their [=request/client=] is a [=secure context=] **and** a
       [=CORS-preflight request=] to the target origin is successful.
 
-  3.  [=Requests=] whose [=request/client=]'s [=/address space=]
-      is [=IP address space/public=] are allowed to fetch resources from
+  3.  [=Requests=] whose [=request/client=]'s
+      [=environment settings object/IP address space=] is
+      [=IP address space/public=] are allowed to fetch resources from
       [=IP address space/public=] addresses as they do today, but may only
       request [=IP address space/private=] and [=IP address space/local=]
       resources if their [=request/client=] is a [=secure context=] <em>and</em>
@@ -473,19 +475,19 @@ spec:fetch; type:dfn; for:cache; text:cache match
   To those ends:
 
   1.  [=Connection=] objects are given a new
-      <dfn export for="connection">address space</dfn>, whose value is the
-      [=IP address space=] to which the connection's remote endpoint belongs.
+      <dfn export for="connection">IP address space</dfn>, whose value is the
+      [=/IP address space=] to which the connection's remote endpoint belongs.
       This applies to WebSocket connections too.
 
   1.  [=Response=] objects are given a new
-      <dfn export for="response">address space</dfn> property, whose value is
-      an [=IP address space=], initially null.
+      <dfn export for="response">IP address space</dfn> property, whose value is
+      an [=/IP address space=], initially null.
 
   1.  The [$HTTP-network fetch$] algorithm is amended to add a new step in
       between steps 7.1 and 7.2, after successfully obtaining a connection:
 
-      > 7.2. Set <var ignore>response</var>'s [=response/address space=] to
-      >      <var ignore>connection</var>'s [=connection/address space=].
+      > 7.2. Set <var ignore>response</var>'s [=response/IP address space=] to
+      >      <var ignore>connection</var>'s [=connection/IP address space=].
 
   1.  The <a>HTTP fetch</a> algorithm should be adjusted to ensure that a
       preflight is triggered for all <a>private network requests</a>. This might
@@ -598,44 +600,45 @@ spec:fetch; type:dfn; for:cache; text:cache match
   <h3 id="integration-html">Integration with HTML</h3>
 
   To support the checks in [[FETCH]], user agents must remember the source
-  [=/address space=] of contexts in which network requests are made. To this
+  [=/IP address space=] of contexts in which network requests are made. To this
   effect, the [[HTML]] specification is patched as follows:
 
-  1.  An [=/address space=] property is persisted on a number of objects:
+  1.  An [=/IP address space=] property is persisted on a number of objects:
 
       1.  {{Document}} objects are given an
-          <dfn export for="Document">address space</dfn> property, whose value
-          is an [=IP address space=].
+          <dfn export for="Document">IP address space</dfn> property, whose
+          value is an [=/IP address space=].
 
       1.  {{WorkerGlobalScope}} objects are given an
-          <dfn export for="WorkerGlobalScope">address space</dfn> property,
-          whose value is an [=IP address space=].
+          <dfn export for="WorkerGlobalScope">IP address space</dfn> property,
+          whose value is an [=/IP address space=].
 
-      1.  [[Environment settings objects]] are given an
-          <dfn export for="environment settings object">address space</dfn>
+      1.  [=Environment settings objects=] are given an
+          <dfn export for="environment settings object">IP address space</dfn>
           accessor, which has the following implementations:
 
-          1.  For {{Window}} objects: return the [=Document/address space=] of
-              <var ignore>window</var>'s [=associated Document=].
+          1.  For {{Window}} objects: return the [=Document/IP address space=]
+              of <var ignore>window</var>'s [=associated Document=].
 
           1.  For {{WorkerGlobalScope}} objects: return
               <var ignore>worker global scope</var>'s
-              [=WorkerGlobalScope/address space=].
+              [=WorkerGlobalScope/IP address space=].
 
   1.  The [$create a new browsing context$] algorithm is amended with an extra
       step in between the existing steps 19 and 20. Thus the initial
-      `about:blank` document inherits its creator's [=Document/address space=]:
+      `about:blank` document inherits its creator's
+      [=Document/IP address space=]:
 
       > 20.  If |creator| is non-null, then set <var ignore>document</var>'s
-      >      [=Document/address space=] to to |creator|'s
-      >      [=Document/address space=].
+      >      [=Document/IP address space=] to to |creator|'s
+      >      [=Document/IP address space=].
 
   1.  The [$initialize the Document object$] algorithm is amended with an extra
       step in between the existing steps 10 and 11, before the new
       {{Document}}'s [=Document/CSP list=] is initialized:
 
-      > 12.  Set <var ignore>document</var>'s [=Document/address space=] to
-      >      <var ignore>response</var>'s [=response/address space=].
+      > 12.  Set <var ignore>document</var>'s [=Document/IP address space=] to
+      >      <var ignore>response</var>'s [=response/IP address space=].
 
   1.  The [$run a worker$] algorithm is amended with two extra steps in between
       the existing steps 14.4 and 14.5, after the new {{WorkerGlobalScope}}'s
@@ -643,11 +646,11 @@ spec:fetch; type:dfn; for:cache; text:cache match
 
       > 14.5. If |response|'s [=response/url=]'s [=url/scheme=] is a
       >       [=local scheme=], then set |worker global scope|'s
-      >       [=WorkerGlobalScope/address space=] to <var ignore>owner</var>'s
-      >       [=WorkerGlobalScope/address space=].
+      >       [=WorkerGlobalScope/IP address space=] to
+      >       <var ignore>owner</var>'s [=WorkerGlobalScope/IP address space=].
       > 14.5. Otherwise, set |worker global scope|'s
-      >       [=WorkerGlobalScope/address space=] to |response|'s
-      >       [=response/address space=].
+      >       [=WorkerGlobalScope/IP address space=] to |response|'s
+      >       [=response/IP address space=].
 
   ISSUE(WICG/cors-rfc1918#27): Find a place to insert address space inheritance
   from the navigation initiator for `data:` URLs.
@@ -659,17 +662,17 @@ spec:fetch; type:dfn; for:cache; text:cache match
   <div class="example">
     Assuming that `example.com` resolves to a [=public address=] (say,
     `123.123.123.123`), then the {{Document}} created when navigating to
-    `https://example.com/document.html` will have its [=Document/address space=]
-    property set to [=IP address space/public=].
+    `https://example.com/document.html` will have its
+    [=Document/IP address space=] property set to [=IP address space/public=].
 
     If this {{Document}} then embeds an `about:srcdoc` iframe, then the child
-    frame's {{Document}} will have its [=Document/address space=] property set
-    to [=IP address space/public=].
+    frame's {{Document}} will have its [=Document/IP address space=] property
+    set to [=IP address space/public=].
 
     If, on the other hand, `example.com` resolved to a [=local address=]
     (say, `127.0.0.1`), then the {{Document}} created when navigating to
-    `https://example.com/document.html` will have its [=Document/address space=]
-    property set to "`local`".
+    `https://example.com/document.html` will have its
+    [=Document/IP address space=] property set to [=IP address space/local=].
   </div>
 
 </section>


### PR DESCRIPTION
This PR starts converting English language requirements into actual patches to the HTML (mostly) and Fetch (a tiny bit) specs.

It patches Fetch minimally to support defining the HTML changes, mostly by defining an *address space* property on fetch responses. The changes to HTML are more extensive, but I am not yet sure they are enough. I think work remains to be done on `blob:` URLs, and I need to check what happens during navigations to cover `data:` and `javascript:` URLs. Any pointers there are appreciated.

Along the way, I renamed `address space` to `IP address space`, aligning with the URL spec's [IPv{4,6} address](https://url.spec.whatwg.org/#concept-ipv4) concepts.

This PR furthers #27 without fixing it entirely yet.